### PR TITLE
Add procurement requirements documentation

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,50 @@
+# Procurement Management Requirements
+
+## Roles and Permissions
+
+### Requester
+- **Responsibilities:** Initiate procurement requests with clear descriptions and supporting documents.
+- **Permissions:** Create and view their own requests; track status; edit or cancel before approval.
+- **Key Workflows:**
+  - Submit new request with item details and justification.
+  - Monitor request lifecycle until completion.
+
+### Approver
+- **Responsibilities:** Review requests for completeness, budget compliance, and policy adherence.
+- **Permissions:** View pending requests; approve or reject; add comments or request changes.
+- **Key Workflows:**
+  - Receive notification when new request awaits approval.
+  - Approve, reject, or return for changes within the approval stage.
+
+### Procurement Officer
+- **Responsibilities:** Convert approved requests into purchase orders and coordinate with vendors.
+- **Permissions:** Access approved requests; create and manage purchase orders; update order status.
+- **Key Workflows:**
+  - Validate approved requests and select vendors.
+  - Place orders and record order confirmations.
+  - Update system when goods or services are received.
+
+### Administrator
+- **Responsibilities:** Maintain system configuration, user accounts, and role assignments.
+- **Permissions:** Full system access including role management and audit logs.
+- **Key Workflows:**
+  - Create or deactivate user accounts.
+  - Assign roles and adjust permissions based on organizational policy.
+
+## Workflows
+
+### Request Lifecycle
+1. Requester submits a new procurement request.
+2. Approver reviews and approves/rejects the request.
+3. Procurement Officer converts approved request into a purchase order.
+4. Order status updated through fulfillment and closure.
+
+### Approvals
+- Approvers receive alerts for pending requests.
+- Approval decisions recorded with optional comments.
+- Rejected or returned requests notify the requester for revision.
+
+### Order Placement
+1. Procurement Officer reviews approved requests and selects suppliers.
+2. Purchase order created and sent to vendor.
+3. Order tracked until goods/services are received and confirmed.


### PR DESCRIPTION
## Summary
- add documentation for procurement roles, permissions, and workflows

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68c60c68e574832aa8deac69753f6860