### PR TITLE
Add UI wireframes and component library choice

### DIFF
--- a/docs/ui-prototypes/README.md
+++ b/docs/ui-prototypes/README.md
@@ -1,0 +1,15 @@
+# UI Prototypes
+
+This directory houses early-stage wireframes for the procurement management interface.
+
+## Component Library
+
+- **Selected Library:** Material UI
+
+## Wireframes
+
+- Dashboard: [dashboard-wireframe.svg](dashboard-wireframe.svg)
+- Request Form: [request-form-wireframe.svg](request-form-wireframe.svg)
+- Approvals: [approval-wireframe.svg](approval-wireframe.svg)
+
+These SVGs provide a simple reference for layout and component placement before high-fidelity designs are produced.

--- a/docs/ui-prototypes/approval-wireframe.svg
+++ b/docs/ui-prototypes/approval-wireframe.svg
@@ -1,0 +1,12 @@
+<svg width="800" height="600" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="800" height="50" fill="#eeeeee" stroke="#000" />
+  <text x="10" y="30" font-family="Arial" font-size="14">Top Navigation</text>
+  <rect x="0" y="50" width="800" height="550" fill="#ffffff" stroke="#000" />
+  <text x="10" y="80" font-family="Arial" font-size="14">Approval Queue</text>
+  <rect x="10" y="100" width="780" height="200" fill="#fafafa" stroke="#000" />
+  <text x="20" y="120" font-family="Arial" font-size="14">Request Details</text>
+  <rect x="10" y="310" width="780" height="150" fill="#fafafa" stroke="#000" />
+  <text x="20" y="330" font-family="Arial" font-size="14">Comments</text>
+  <rect x="10" y="470" width="780" height="80" fill="#fafafa" stroke="#000" />
+  <text x="20" y="500" font-family="Arial" font-size="14">Approve / Reject Buttons</text>
+</svg>

--- a/docs/ui-prototypes/dashboard-wireframe.svg
+++ b/docs/ui-prototypes/dashboard-wireframe.svg
@@ -1,0 +1,10 @@
+<svg width="800" height="600" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="800" height="50" fill="#eeeeee" stroke="#000" />
+  <text x="10" y="30" font-family="Arial" font-size="14">Top Navigation</text>
+  <rect x="0" y="50" width="200" height="550" fill="#f5f5f5" stroke="#000" />
+  <text x="10" y="80" font-family="Arial" font-size="14">Sidebar</text>
+  <rect x="200" y="50" width="600" height="275" fill="#ffffff" stroke="#000" />
+  <text x="210" y="80" font-family="Arial" font-size="14">Stats / Overview</text>
+  <rect x="200" y="325" width="600" height="275" fill="#ffffff" stroke="#000" />
+  <text x="210" y="355" font-family="Arial" font-size="14">Recent Activity</text>
+</svg>

--- a/docs/ui-prototypes/request-form-wireframe.svg
+++ b/docs/ui-prototypes/request-form-wireframe.svg
@@ -1,0 +1,12 @@
+<svg width="800" height="600" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="800" height="50" fill="#eeeeee" stroke="#000" />
+  <text x="10" y="30" font-family="Arial" font-size="14">Top Navigation</text>
+  <rect x="0" y="50" width="800" height="550" fill="#ffffff" stroke="#000" />
+  <text x="10" y="80" font-family="Arial" font-size="14">Request Form Fields</text>
+  <rect x="10" y="100" width="780" height="200" fill="#fafafa" stroke="#000" />
+  <text x="20" y="120" font-family="Arial" font-size="14">Item Details</text>
+  <rect x="10" y="310" width="780" height="150" fill="#fafafa" stroke="#000" />
+  <text x="20" y="330" font-family="Arial" font-size="14">Justification</text>
+  <rect x="10" y="470" width="780" height="80" fill="#fafafa" stroke="#000" />
+  <text x="20" y="500" font-family="Arial" font-size="14">Attachments &amp; Submit</text>
+</svg>


### PR DESCRIPTION
## Summary
- document Material UI as the chosen UI library
- add SVG wireframes for dashboard, request form, and approvals

## Testing
- `npm test` *(fails: ENOENT, no package.json)*
- `pytest` *(passes: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68c60f1a862c832a8964a7dc1f9864f8