### PR TITLE
Add PostgreSQL models and schema

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -1,0 +1,9 @@
+import pkg from 'pg';
+
+const { Pool } = pkg;
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+export default pool;

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,7 +1,18 @@
 import express from 'express';
+import pool from './db.js';
 
 const app = express();
 const port = process.env.PORT || 3000;
+
+pool
+  .connect()
+  .then((client) => {
+    client.release();
+    console.log('Connected to PostgreSQL');
+  })
+  .catch((err) => {
+    console.error('Failed to connect to PostgreSQL', err);
+  });
 
 app.get('/', (req, res) => {
   res.send('Hello World from backend!');

--- a/backend/models/approval.js
+++ b/backend/models/approval.js
@@ -1,0 +1,15 @@
+import pool from '../db.js';
+
+export async function createApproval({ requestId, approverId, status, comments }) {
+  const result = await pool.query(
+    `INSERT INTO approvals (request_id, approver_id, status, comments)
+     VALUES ($1, $2, $3, $4) RETURNING *`,
+    [requestId, approverId, status, comments],
+  );
+  return result.rows[0];
+}
+
+export async function findApprovalById(id) {
+  const result = await pool.query('SELECT * FROM approvals WHERE id = $1', [id]);
+  return result.rows[0];
+}

--- a/backend/models/procurementRequest.js
+++ b/backend/models/procurementRequest.js
@@ -1,0 +1,15 @@
+import pool from '../db.js';
+
+export async function createRequest({ userId, itemName, quantity, status = 'pending' }) {
+  const result = await pool.query(
+    `INSERT INTO procurement_requests (user_id, item_name, quantity, status)
+     VALUES ($1, $2, $3, $4) RETURNING *`,
+    [userId, itemName, quantity, status],
+  );
+  return result.rows[0];
+}
+
+export async function findRequestById(id) {
+  const result = await pool.query('SELECT * FROM procurement_requests WHERE id = $1', [id]);
+  return result.rows[0];
+}

--- a/backend/models/purchaseOrder.js
+++ b/backend/models/purchaseOrder.js
@@ -1,0 +1,15 @@
+import pool from '../db.js';
+
+export async function createPurchaseOrder({ requestId, orderNumber, vendor, totalAmount }) {
+  const result = await pool.query(
+    `INSERT INTO purchase_orders (request_id, order_number, vendor, total_amount)
+     VALUES ($1, $2, $3, $4) RETURNING *`,
+    [requestId, orderNumber, vendor, totalAmount],
+  );
+  return result.rows[0];
+}
+
+export async function findPurchaseOrderById(id) {
+  const result = await pool.query('SELECT * FROM purchase_orders WHERE id = $1', [id]);
+  return result.rows[0];
+}

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -1,0 +1,14 @@
+import pool from '../db.js';
+
+export async function createUser({ name, email }) {
+  const result = await pool.query(
+    'INSERT INTO users (name, email) VALUES ($1, $2) RETURNING *',
+    [name, email],
+  );
+  return result.rows[0];
+}
+
+export async function findUserById(id) {
+  const result = await pool.query('SELECT * FROM users WHERE id = $1', [id]);
+  return result.rows[0];
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "pg": "^8.11.5"
   },
   "devDependencies": {
     "eslint": "^8.57.0",

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,0 +1,32 @@
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  email VARCHAR(255) UNIQUE NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS procurement_requests (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+  item_name VARCHAR(255) NOT NULL,
+  quantity INTEGER NOT NULL,
+  status VARCHAR(50) DEFAULT 'pending',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS approvals (
+  id SERIAL PRIMARY KEY,
+  request_id INTEGER REFERENCES procurement_requests(id) ON DELETE CASCADE,
+  approver_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+  status VARCHAR(50) NOT NULL,
+  comments TEXT,
+  approved_at TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS purchase_orders (
+  id SERIAL PRIMARY KEY,
+  request_id INTEGER REFERENCES procurement_requests(id) ON DELETE CASCADE,
+  order_number VARCHAR(100) NOT NULL,
+  vendor VARCHAR(255) NOT NULL,
+  total_amount NUMERIC(10,2) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- configure PostgreSQL connection using `pg`
- add models for users, procurement requests, approvals, and purchase orders
- include SQL schema for recreating database tables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint)*

------
https://chatgpt.com/codex/tasks/task_e_68c6124bb6fc832a9cc722244b5fd0a1