### PR TITLE
Add request and approval API routes with error handling

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,10 +1,28 @@
 import express from 'express';
+import requestsRouter from './routes/requests.js';
+import approvalsRouter from './routes/approvals.js';
 
 const app = express();
 const port = process.env.PORT || 3000;
 
+app.use(express.json());
+
 app.get('/', (req, res) => {
   res.send('Hello World from backend!');
+});
+
+app.use('/api/requests', requestsRouter);
+app.use('/api/approvals', approvalsRouter);
+
+// 404 handler
+app.use((req, res) => {
+  res.status(404).json({ error: 'Not Found' });
+});
+
+// Error handler
+app.use((err, req, res, next) => {
+  console.error(err);
+  res.status(500).json({ error: 'Internal Server Error' });
 });
 
 app.listen(port, () => {

--- a/backend/routes/approvals.js
+++ b/backend/routes/approvals.js
@@ -1,0 +1,52 @@
+import { Router } from 'express';
+
+const router = Router();
+
+let approvals = [];
+let nextId = 1;
+
+// Get all approvals
+router.get('/', (req, res) => {
+  res.json(approvals);
+});
+
+// Get a single approval by ID
+router.get('/:id', (req, res) => {
+  const id = Number(req.params.id);
+  const approval = approvals.find((a) => a.id === id);
+  if (!approval) {
+    return res.status(404).json({ error: 'Approval not found' });
+  }
+  return res.json(approval);
+});
+
+// Create a new approval
+router.post('/', (req, res) => {
+  const approval = { id: nextId++, status: 'pending', ...req.body };
+  approvals.push(approval);
+  return res.status(201).json(approval);
+});
+
+// Update an approval
+router.put('/:id', (req, res) => {
+  const id = Number(req.params.id);
+  const index = approvals.findIndex((a) => a.id === id);
+  if (index === -1) {
+    return res.status(404).json({ error: 'Approval not found' });
+  }
+  approvals[index] = { id, ...approvals[index], ...req.body };
+  return res.json(approvals[index]);
+});
+
+// Delete an approval
+router.delete('/:id', (req, res) => {
+  const id = Number(req.params.id);
+  const index = approvals.findIndex((a) => a.id === id);
+  if (index === -1) {
+    return res.status(404).json({ error: 'Approval not found' });
+  }
+  approvals.splice(index, 1);
+  return res.status(204).end();
+});
+
+export default router;

--- a/backend/routes/requests.js
+++ b/backend/routes/requests.js
@@ -1,0 +1,52 @@
+import { Router } from 'express';
+
+const router = Router();
+
+let requests = [];
+let nextId = 1;
+
+// Get all requests
+router.get('/', (req, res) => {
+  res.json(requests);
+});
+
+// Get a single request by ID
+router.get('/:id', (req, res) => {
+  const id = Number(req.params.id);
+  const request = requests.find((r) => r.id === id);
+  if (!request) {
+    return res.status(404).json({ error: 'Request not found' });
+  }
+  return res.json(request);
+});
+
+// Create a new request
+router.post('/', (req, res) => {
+  const request = { id: nextId++, ...req.body };
+  requests.push(request);
+  return res.status(201).json(request);
+});
+
+// Update a request
+router.put('/:id', (req, res) => {
+  const id = Number(req.params.id);
+  const index = requests.findIndex((r) => r.id === id);
+  if (index === -1) {
+    return res.status(404).json({ error: 'Request not found' });
+  }
+  requests[index] = { id, ...req.body };
+  return res.json(requests[index]);
+});
+
+// Delete a request
+router.delete('/:id', (req, res) => {
+  const id = Number(req.params.id);
+  const index = requests.findIndex((r) => r.id === id);
+  if (index === -1) {
+    return res.status(404).json({ error: 'Request not found' });
+  }
+  requests.splice(index, 1);
+  return res.status(204).end();
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add Express routers for requests and approvals with in-memory CRUD operations
- wire new routes into backend server with JSON parsing and error handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6124cac58832a9fc7e56deaf44b5c