### PR TITLE
Add JWT authentication and role-based authorization

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,7 +1,31 @@
 import express from 'express';
+import dotenv from 'dotenv';
+import { authRouter, ROLES } from './routes/auth.js';
+import { authenticateToken, authorizeRoles } from './middleware/auth.js';
+
+dotenv.config();
+
+if (!process.env.JWT_SECRET) {
+  console.error('JWT_SECRET is not defined');
+  process.exit(1);
+}
 
 const app = express();
 const port = process.env.PORT || 3000;
+
+app.use(express.json());
+
+app.use('/auth', authRouter);
+
+// Example protected route requiring administrator role
+app.get(
+  '/admin',
+  authenticateToken,
+  authorizeRoles(ROLES.ADMINISTRATOR),
+  (req, res) => {
+    res.json({ message: 'Administrator content' });
+  }
+);
 
 app.get('/', (req, res) => {
   res.send('Hello World from backend!');

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,0 +1,30 @@
+import jwt from 'jsonwebtoken';
+
+// Middleware to authenticate requests using JWT
+export function authenticateToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+
+  if (!token) {
+    return res.sendStatus(401);
+  }
+
+  try {
+    const user = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = user;
+    next();
+  } catch {
+    res.sendStatus(403);
+  }
+}
+
+// Middleware factory to authorize based on user roles
+export function authorizeRoles(...allowedRoles) {
+  return function (req, res, next) {
+    if (!req.user || !allowedRoles.includes(req.user.role)) {
+      return res.sendStatus(403);
+    }
+    next();
+  };
+}
+

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,10 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "express": "^4.19.2"
+    "bcryptjs": "^2.4.3",
+    "dotenv": "^16.3.1",
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "eslint": "^8.57.0",

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,0 +1,53 @@
+import express from 'express';
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+
+export const ROLES = {
+  REQUESTER: 'requester',
+  APPROVER: 'approver',
+  PROCUREMENT_OFFICER: 'procurement_officer',
+  ADMINISTRATOR: 'administrator',
+};
+
+const users = [];
+
+export const authRouter = express.Router();
+
+authRouter.post('/register', async (req, res) => {
+  const { username, password, role } = req.body;
+
+  if (!username || !password || !role || !Object.values(ROLES).includes(role)) {
+    return res.status(400).json({ message: 'Invalid registration data' });
+  }
+
+  const existing = users.find((u) => u.username === username);
+  if (existing) {
+    return res.status(409).json({ message: 'User already exists' });
+  }
+
+  const passwordHash = await bcrypt.hash(password, 10);
+  users.push({ username, passwordHash, role });
+  res.status(201).json({ message: 'User registered' });
+});
+
+authRouter.post('/login', async (req, res) => {
+  const { username, password } = req.body;
+  const user = users.find((u) => u.username === username);
+  if (!user) {
+    return res.status(401).json({ message: 'Invalid credentials' });
+  }
+
+  const valid = await bcrypt.compare(password, user.passwordHash);
+  if (!valid) {
+    return res.status(401).json({ message: 'Invalid credentials' });
+  }
+
+  const token = jwt.sign(
+    { username: user.username, role: user.role },
+    process.env.JWT_SECRET,
+    { expiresIn: '1h' }
+  );
+
+  res.json({ token });
+});
+


### PR DESCRIPTION
## Summary
- add `/auth/register` and `/auth/login` routes that hash passwords and issue JWTs
- introduce middleware to authenticate tokens and restrict access by role
- load JWT secret from env and add supporting dependencies

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/bcryptjs)*

------
https://chatgpt.com/codex/tasks/task_e_68c6124d6000832aa9f3621e24076327