### PR TITLE
Add procurement management pages with Material UI

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -4,6 +4,11 @@ export default [
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
     },
     rules: {},
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,8 +11,12 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@mui/material": "^5.15.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.2"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,3 +1,32 @@
+import { AppBar, Toolbar, Button, Container } from '@mui/material';
+import { Routes, Route, Link } from 'react-router-dom';
+import RequestForm from './pages/RequestForm.jsx';
+import Approvals from './pages/Approvals.jsx';
+import OrderStatus from './pages/OrderStatus.jsx';
+
 export default function App() {
-  return <h1>Hello World from frontend!</h1>;
+  return (
+    <>
+      <AppBar position="static">
+        <Toolbar>
+          <Button color="inherit" component={Link} to="/">
+            Submit
+          </Button>
+          <Button color="inherit" component={Link} to="/approvals">
+            Approvals
+          </Button>
+          <Button color="inherit" component={Link} to="/orders">
+            Orders
+          </Button>
+        </Toolbar>
+      </AppBar>
+      <Container sx={{ mt: 2 }}>
+        <Routes>
+          <Route path="/" element={<RequestForm />} />
+          <Route path="/approvals" element={<Approvals />} />
+          <Route path="/orders" element={<OrderStatus />} />
+        </Routes>
+      </Container>
+    </>
+  );
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
 );

--- a/frontend/src/pages/Approvals.jsx
+++ b/frontend/src/pages/Approvals.jsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { Container, List, ListItem, ListItemText, Button, Stack } from '@mui/material';
+
+export default function Approvals() {
+  const [requests, setRequests] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/requests/pending')
+      .then((res) => res.json())
+      .then(setRequests)
+      .catch(() => setRequests([]));
+  }, []);
+
+  const handleAction = async (id, action) => {
+    await fetch(`/api/requests/${id}/${action}`, { method: 'POST' });
+    setRequests((current) => current.filter((r) => r.id !== id));
+  };
+
+  return (
+    <Container sx={{ mt: 2 }}>
+      <h2>Pending Requests</h2>
+      <List>
+        {requests.map((req) => (
+          <ListItem key={req.id} disableGutters>
+            <ListItemText primary={`${req.item} - ${req.quantity}`} />
+            <Stack direction="row" spacing={1}>
+              <Button
+                variant="contained"
+                color="success"
+                onClick={() => handleAction(req.id, 'approve')}
+              >
+                Approve
+              </Button>
+              <Button
+                variant="contained"
+                color="error"
+                onClick={() => handleAction(req.id, 'reject')}
+              >
+                Reject
+              </Button>
+            </Stack>
+          </ListItem>
+        ))}
+      </List>
+    </Container>
+  );
+}
+

--- a/frontend/src/pages/OrderStatus.jsx
+++ b/frontend/src/pages/OrderStatus.jsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import { Container, List, ListItem, ListItemText, Chip } from '@mui/material';
+
+export default function OrderStatus() {
+  const [orders, setOrders] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/orders')
+      .then((res) => res.json())
+      .then(setOrders)
+      .catch(() => setOrders([]));
+  }, []);
+
+  return (
+    <Container sx={{ mt: 2 }}>
+      <h2>Order Status</h2>
+      <List>
+        {orders.map((order) => (
+          <ListItem key={order.id} disableGutters>
+            <ListItemText primary={`${order.item} - ${order.quantity}`} />
+            <Chip label={order.status} sx={{ ml: 2 }} />
+          </ListItem>
+        ))}
+      </List>
+    </Container>
+  );
+}
+

--- a/frontend/src/pages/RequestForm.jsx
+++ b/frontend/src/pages/RequestForm.jsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { Container, TextField, Button } from '@mui/material';
+
+export default function RequestForm() {
+  const [item, setItem] = useState('');
+  const [quantity, setQuantity] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await fetch('/api/requests', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ item, quantity }),
+    });
+    setItem('');
+    setQuantity('');
+  };
+
+  return (
+    <Container sx={{ mt: 2 }}>
+      <h2>Submit Request</h2>
+      <form onSubmit={handleSubmit}>
+        <TextField
+          label="Item"
+          value={item}
+          onChange={(e) => setItem(e.target.value)}
+          fullWidth
+          margin="normal"
+        />
+        <TextField
+          label="Quantity"
+          value={quantity}
+          onChange={(e) => setQuantity(e.target.value)}
+          fullWidth
+          margin="normal"
+        />
+        <Button type="submit" variant="contained" sx={{ mt: 2 }}>
+          Submit
+        </Button>
+      </form>
+    </Container>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add submission, approval, and order status pages in React
- integrate React Router and Material UI navigation
- configure ESLint and dependencies for JSX and MUI

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: vite not found)


------
https://chatgpt.com/codex/tasks/task_e_68c6124e3de4832a8e9d97219c2f1554