### PR TITLE
Add Vitest testing and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,12 +1,16 @@
 import express from 'express';
 
 const app = express();
-const port = process.env.PORT || 3000;
 
 app.get('/', (req, res) => {
   res.send('Hello World from backend!');
 });
 
-app.listen(port, () => {
-  console.log(`Server running on port ${port}`);
-});
+if (process.env.NODE_ENV !== 'test') {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+}
+
+export default app;

--- a/backend/index.test.js
+++ b/backend/index.test.js
@@ -1,0 +1,11 @@
+import request from 'supertest';
+import app from './index.js';
+import { describe, it, expect } from 'vitest';
+
+describe('GET /', () => {
+  it('responds with greeting', async () => {
+    const res = await request(app).get('/');
+    expect(res.status).toBe(200);
+    expect(res.text).toBe('Hello World from backend!');
+  });
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node index.js",
     "lint": "eslint .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "test": "vitest"
   },
   "dependencies": {
     "express": "^4.19.2"
@@ -15,6 +16,8 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
-    "prettier": "^3.1.0"
+    "prettier": "^3.1.0",
+    "supertest": "^6.3.3",
+    "vitest": "^1.5.0"
   }
 }

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -4,6 +4,11 @@ export default [
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
     },
     rules: {},
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint src --ext jsx",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -19,6 +20,10 @@
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.33.2",
     "prettier": "^3.1.0",
-    "vite": "^5.1.0"
+    "vite": "^5.1.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.4.2",
+    "jsdom": "^24.0.0",
+    "vitest": "^1.5.0"
   }
 }

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect } from 'vitest';
+import App from './App.jsx';
+
+describe('App', () => {
+  it('renders greeting', () => {
+    render(<App />);
+    expect(screen.getByText('Hello World from frontend!')).toBeInTheDocument();
+  });
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,4 +3,8 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
 });


### PR DESCRIPTION
## Summary
- set up Vitest for backend and frontend with example tests
- configure Vite and ESLint for testing
- add CI workflow running lint and tests for each project

## Testing
- `npm test` (fails: sh: 1: vitest: not found)
- `npm run lint` (frontend)
- `npm test` (fails: sh: 1: vitest: not found)
- `npm run lint` (backend)

------
https://chatgpt.com/codex/tasks/task_e_68c6124efa70832a90992fe01fd64d2d