### PR TITLE
Add authentication and role-based authorization

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,29 +1,24 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a/backend/index.js b/backend/index.js
-index 08a063023e6a56a41c8abebc2fb143f3ac649ba7..c7374b2efd5581e42067d65c4f238696745ca5fd 100644
---- a/backend/index.js
-+++ b/backend/index.js
-@@ -1,12 +1,16 @@
- import express from 'express';
- 
- const app = express();
--const port = process.env.PORT || 3000;
- 
- app.get('/', (req, res) => {
-   res.send('Hello World from backend!');
- });
- 
--app.listen(port, () => {
--  console.log(`Server running on port ${port}`);
--});
-+if (process.env.NODE_ENV !== 'test') {
-+  const port = process.env.PORT || 3000;
-+  app.listen(port, () => {
-+    console.log(`Server running on port ${port}`);
-+  });
-+}
-+
-+export default app;
- 
-EOF
-)
+import express from 'express';
+import { authRouter } from './routes/auth.js';
+import requestsRouter from './routes/requests.js';
+import approvalsRouter from './routes/approvals.js';
+
+const app = express();
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.send('Hello World from backend!');
+});
+
+app.use('/auth', authRouter);
+app.use('/requests', requestsRouter);
+app.use('/approvals', approvalsRouter);
+
+if (process.env.NODE_ENV !== 'test') {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+}
+
+export default app;

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -10,7 +10,7 @@ export function authenticateToken(req, res, next) {
   }
 
   try {
-    const user = jwt.verify(token, process.env.JWT_SECRET);
+    const user = jwt.verify(token, process.env.JWT_SECRET || 'dev-secret');
     req.user = user;
     next();
   } catch {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,34 +1,25 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a/backend/package.json b/backend/package.json
-index 8764ed51676b7e6aaa7317cfe6eceb927d3557a6..372f80a969a2215ff2e94c107a619d1ed19b5b54 100644
---- a/backend/package.json
-+++ b/backend/package.json
-@@ -1,20 +1,23 @@
- {
-   "name": "backend",
-   "version": "1.0.0",
-   "private": true,
-   "type": "module",
-   "scripts": {
-     "start": "node index.js",
-     "lint": "eslint .",
--    "format": "prettier --write ."
-+    "format": "prettier --write .",
-+    "test": "vitest"
-   },
-   "dependencies": {
-     "express": "^4.19.2"
-   },
-   "devDependencies": {
-     "eslint": "^8.57.0",
-     "eslint-config-prettier": "^9.1.0",
-     "eslint-plugin-prettier": "^5.1.3",
--    "prettier": "^3.1.0"
-+    "prettier": "^3.1.0",
-+    "supertest": "^6.3.3",
-+    "vitest": "^1.5.0"
-   }
- }
- 
-EOF
-)
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node index.js",
+    "lint": "eslint .",
+    "format": "prettier --write .",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "prettier": "^3.1.0",
+    "supertest": "^6.3.3",
+    "vitest": "^1.5.0"
+  }
+}

--- a/backend/routes/approvals.js
+++ b/backend/routes/approvals.js
@@ -1,17 +1,22 @@
 import { Router } from 'express';
+import { authenticateToken, authorizeRoles } from '../middleware/auth.js';
+import { ROLES } from './auth.js';
 
 const router = Router();
+
+// all approval routes require a valid JWT
+router.use(authenticateToken);
 
 let approvals = [];
 let nextId = 1;
 
-// Get all approvals
-router.get('/', (req, res) => {
+// Get all approvals (Approver, Procurement Officer, Administrator)
+router.get('/', authorizeRoles(ROLES.APPROVER, ROLES.PROCUREMENT_OFFICER, ROLES.ADMINISTRATOR), (req, res) => {
   res.json(approvals);
 });
 
-// Get a single approval by ID
-router.get('/:id', (req, res) => {
+// Get a single approval by ID (Approver, Procurement Officer, Administrator)
+router.get('/:id', authorizeRoles(ROLES.APPROVER, ROLES.PROCUREMENT_OFFICER, ROLES.ADMINISTRATOR), (req, res) => {
   const id = Number(req.params.id);
   const approval = approvals.find((a) => a.id === id);
   if (!approval) {
@@ -20,15 +25,15 @@ router.get('/:id', (req, res) => {
   return res.json(approval);
 });
 
-// Create a new approval
-router.post('/', (req, res) => {
+// Create a new approval (Approver, Procurement Officer, Administrator)
+router.post('/', authorizeRoles(ROLES.APPROVER, ROLES.PROCUREMENT_OFFICER, ROLES.ADMINISTRATOR), (req, res) => {
   const approval = { id: nextId++, status: 'pending', ...req.body };
   approvals.push(approval);
   return res.status(201).json(approval);
 });
 
-// Update an approval
-router.put('/:id', (req, res) => {
+// Update an approval (Approver, Procurement Officer, Administrator)
+router.put('/:id', authorizeRoles(ROLES.APPROVER, ROLES.PROCUREMENT_OFFICER, ROLES.ADMINISTRATOR), (req, res) => {
   const id = Number(req.params.id);
   const index = approvals.findIndex((a) => a.id === id);
   if (index === -1) {
@@ -38,8 +43,8 @@ router.put('/:id', (req, res) => {
   return res.json(approvals[index]);
 });
 
-// Delete an approval
-router.delete('/:id', (req, res) => {
+// Delete an approval (Administrator only)
+router.delete('/:id', authorizeRoles(ROLES.ADMINISTRATOR), (req, res) => {
   const id = Number(req.params.id);
   const index = approvals.findIndex((a) => a.id === id);
   if (index === -1) {

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -44,7 +44,7 @@ authRouter.post('/login', async (req, res) => {
 
   const token = jwt.sign(
     { username: user.username, role: user.role },
-    process.env.JWT_SECRET,
+    process.env.JWT_SECRET || 'dev-secret',
     { expiresIn: '1h' }
   );
 

--- a/backend/routes/requests.js
+++ b/backend/routes/requests.js
@@ -1,6 +1,11 @@
 import { Router } from 'express';
+import { authenticateToken, authorizeRoles } from '../middleware/auth.js';
+import { ROLES } from './auth.js';
 
 const router = Router();
+
+// all request routes require a valid JWT
+router.use(authenticateToken);
 
 let requests = [];
 let nextId = 1;
@@ -20,15 +25,15 @@ router.get('/:id', (req, res) => {
   return res.json(request);
 });
 
-// Create a new request
-router.post('/', (req, res) => {
+// Create a new request (Requester or Administrator)
+router.post('/', authorizeRoles(ROLES.REQUESTER, ROLES.ADMINISTRATOR), (req, res) => {
   const request = { id: nextId++, ...req.body };
   requests.push(request);
   return res.status(201).json(request);
 });
 
-// Update a request
-router.put('/:id', (req, res) => {
+// Update a request (Requester or Administrator)
+router.put('/:id', authorizeRoles(ROLES.REQUESTER, ROLES.ADMINISTRATOR), (req, res) => {
   const id = Number(req.params.id);
   const index = requests.findIndex((r) => r.id === id);
   if (index === -1) {
@@ -38,8 +43,8 @@ router.put('/:id', (req, res) => {
   return res.json(requests[index]);
 });
 
-// Delete a request
-router.delete('/:id', (req, res) => {
+// Delete a request (Administrator only)
+router.delete('/:id', authorizeRoles(ROLES.ADMINISTRATOR), (req, res) => {
   const id = Number(req.params.id);
   const index = requests.findIndex((r) => r.id === id);
   if (index === -1) {


### PR DESCRIPTION
## Summary
- Implement JWT-based register/login endpoints
- Add token verification and role checking middleware
- Secure request and approval routes with role-based access control
- Configure express app and package metadata for new features

## Testing
- `npm run lint`
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c61636a64c832aa020d984f9cfed32