### PR TITLE
Add PostgreSQL database models and migrations

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+backend/migrations

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,0 +1,12 @@
+const { Pool } = require('pg');
+
+const pool = new Pool({
+  connectionString:
+    process.env.DATABASE_URL ||
+    'postgres://postgres:postgres@localhost:5432/procurement_db',
+});
+
+module.exports = {
+  query: (text, params) => pool.query(text, params),
+  pool,
+};

--- a/backend/migrate.js
+++ b/backend/migrate.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const db = require('./db');
+
+const runMigrations = async () => {
+  const migrationsDir = path.join(__dirname, 'migrations');
+  const files = fs.readdirSync(migrationsDir).sort();
+  for (const file of files) {
+    const sql = fs.readFileSync(path.join(migrationsDir, file), 'utf8');
+    await db.query(sql);
+  }
+};
+
+runMigrations()
+  .then(() => {
+    console.log('Migrations completed');
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error('Migration failed', err);
+    process.exit(1);
+  });

--- a/backend/migrations/001_initial.sql
+++ b/backend/migrations/001_initial.sql
@@ -1,0 +1,35 @@
+-- Users table
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  email TEXT UNIQUE NOT NULL
+);
+
+-- Procurement requests
+CREATE TABLE IF NOT EXISTS procurement_requests (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER REFERENCES users(id),
+  description TEXT NOT NULL,
+  amount NUMERIC NOT NULL,
+  status TEXT DEFAULT 'pending',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Approvals
+CREATE TABLE IF NOT EXISTS approvals (
+  id SERIAL PRIMARY KEY,
+  request_id INTEGER REFERENCES procurement_requests(id),
+  approver_id INTEGER REFERENCES users(id),
+  status TEXT NOT NULL,
+  comment TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Purchase orders
+CREATE TABLE IF NOT EXISTS purchase_orders (
+  id SERIAL PRIMARY KEY,
+  request_id INTEGER REFERENCES procurement_requests(id),
+  vendor TEXT NOT NULL,
+  total NUMERIC NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/models/approvals.js
+++ b/backend/models/approvals.js
@@ -1,0 +1,14 @@
+const db = require('../db');
+
+const create = async ({ requestId, approverId, status, comment }) =>
+  db.query(
+    'INSERT INTO approvals (request_id, approver_id, status, comment) VALUES ($1, $2, $3, $4) RETURNING *',
+    [requestId, approverId, status, comment]
+  );
+
+const findAll = async () => db.query('SELECT * FROM approvals');
+
+module.exports = {
+  create,
+  findAll,
+};

--- a/backend/models/procurementRequests.js
+++ b/backend/models/procurementRequests.js
@@ -1,0 +1,14 @@
+const db = require('../db');
+
+const create = async ({ userId, description, amount, status = 'pending' }) =>
+  db.query(
+    'INSERT INTO procurement_requests (user_id, description, amount, status) VALUES ($1, $2, $3, $4) RETURNING *',
+    [userId, description, amount, status]
+  );
+
+const findAll = async () => db.query('SELECT * FROM procurement_requests');
+
+module.exports = {
+  create,
+  findAll,
+};

--- a/backend/models/purchaseOrders.js
+++ b/backend/models/purchaseOrders.js
@@ -1,0 +1,14 @@
+const db = require('../db');
+
+const create = async ({ requestId, vendor, total }) =>
+  db.query(
+    'INSERT INTO purchase_orders (request_id, vendor, total) VALUES ($1, $2, $3) RETURNING *',
+    [requestId, vendor, total]
+  );
+
+const findAll = async () => db.query('SELECT * FROM purchase_orders');
+
+module.exports = {
+  create,
+  findAll,
+};

--- a/backend/models/users.js
+++ b/backend/models/users.js
@@ -1,0 +1,14 @@
+const db = require('../db');
+
+const create = async ({ name, email }) =>
+  db.query('INSERT INTO users (name, email) VALUES ($1, $2) RETURNING *', [
+    name,
+    email,
+  ]);
+
+const findAll = async () => db.query('SELECT * FROM users');
+
+module.exports = {
+  create,
+  findAll,
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,12 +5,14 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "migrate": "node migrate.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "pg": "^8.11.0"
   }
 }


### PR DESCRIPTION
## Summary
- add PostgreSQL connection module
- implement models for users, procurement requests, approvals, and purchase orders
- provide SQL schema and migration runner script

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: Error: no test specified)*
- `npm --prefix backend run migrate` *(fails: Cannot find module 'pg'; installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68c61b27f140832a8621603ee3eb8416