### PR TITLE
Add JWT auth and protected procurement routes

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,9 +1,19 @@
 const express = require('express');
 const app = express();
 
-app.get('/', (req, res) => {
-  res.send('Hello World from backend!');
-});
+const authRoutes = require('./routes/auth');
+const procurementRoutes = require('./routes/procurements');
+const { authenticate, authorize } = require('./middleware/auth');
+
+app.use(express.json());
+
+app.use('/auth', authRoutes);
+app.use(
+  '/procurements',
+  authenticate,
+  authorize(['Finance', 'Requester', 'Buyer', 'Approver', 'Admin']),
+  procurementRoutes
+);
 
 const port = process.env.PORT || 3000;
 app.listen(port, () => {

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,0 +1,34 @@
+const jwt = require('jsonwebtoken');
+
+const secret = process.env.JWT_SECRET || 'secretkey';
+
+const authenticate = (req, res, next) => {
+  const header = req.headers.authorization;
+  if (!header) {
+    return res.status(401).json({ error: 'No token provided' });
+  }
+
+  const [scheme, token] = header.split(' ');
+  if (scheme !== 'Bearer' || !token) {
+    return res.status(401).json({ error: 'Invalid token format' });
+  }
+
+  try {
+    const decoded = jwt.verify(token, secret);
+    req.user = decoded;
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+};
+
+const authorize =
+  (roles = []) =>
+  (req, res, next) => {
+    if (roles.length && !roles.includes(req.user.role)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    next();
+  };
+
+module.exports = { authenticate, authorize };

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.18.2"
+    "bcryptjs": "^2.4.3",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.2"
   }
 }

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+
+const router = express.Router();
+
+const users = [];
+const secret = process.env.JWT_SECRET || 'secretkey';
+
+router.post('/register', (req, res) => {
+  const { username, password, role } = req.body;
+  if (!username || !password || !role) {
+    return res
+      .status(400)
+      .json({ error: 'username, password and role are required' });
+  }
+
+  const existingUser = users.find((u) => u.username === username);
+  if (existingUser) {
+    return res.status(409).json({ error: 'User already exists' });
+  }
+
+  const hashed = bcrypt.hashSync(password, 10);
+  users.push({ id: users.length + 1, username, password: hashed, role });
+  return res.status(201).json({ message: 'User registered' });
+});
+
+router.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  const user = users.find((u) => u.username === username);
+  if (!user) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+
+  const match = bcrypt.compareSync(password, user.password);
+  if (!match) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+
+  const token = jwt.sign({ id: user.id, role: user.role }, secret, {
+    expiresIn: '1h',
+  });
+  return res.json({ token });
+});
+
+module.exports = router;

--- a/backend/routes/procurements.js
+++ b/backend/routes/procurements.js
@@ -1,0 +1,11 @@
+const express = require('express');
+
+const router = express.Router();
+
+const procurements = [{ id: 1, item: 'Laptop', amount: 1200 }];
+
+router.get('/', (req, res) => {
+  res.json(procurements);
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add register/login endpoints that hash passwords and issue JWTs
- verify tokens and role permissions via new auth middleware
- protect procurement routes with authentication and authorization

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint)*
- `npm install` in backend *(fails: 403 Forbidden - GET https://registry.npmjs.org/bcryptjs)*
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68c61b2984f4832aa45bc57ecbce5287