### PR TITLE
Add routed frontend pages with Material UI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,8 +13,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@emotion/react": "^11.11.3",
+    "@emotion/styled": "^11.11.0",
+    "@mui/material": "^5.15.18",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,3 +1,33 @@
+import { AppBar, Toolbar, Button, Container } from '@mui/material';
+import { Routes, Route, Link } from 'react-router-dom';
+import RequestsList from './pages/RequestsList.jsx';
+import Approvals from './pages/Approvals.jsx';
+import PurchaseOrders from './pages/PurchaseOrders.jsx';
+
 export default function App() {
-  return <h1>Hello World from frontend!</h1>;
+  return (
+    <>
+      <AppBar position="static">
+        <Toolbar>
+          <Button color="inherit" component={Link} to="/requests">
+            Requests
+          </Button>
+          <Button color="inherit" component={Link} to="/approvals">
+            Approvals
+          </Button>
+          <Button color="inherit" component={Link} to="/orders">
+            Orders
+          </Button>
+        </Toolbar>
+      </AppBar>
+      <Container sx={{ mt: 2 }}>
+        <Routes>
+          <Route path="/requests" element={<RequestsList />} />
+          <Route path="/approvals" element={<Approvals />} />
+          <Route path="/orders" element={<PurchaseOrders />} />
+          <Route path="/" element={<RequestsList />} />
+        </Routes>
+      </Container>
+    </>
+  );
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/frontend/src/pages/Approvals.jsx
+++ b/frontend/src/pages/Approvals.jsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import {
+  CircularProgress,
+  Alert,
+  List,
+  ListItem,
+  Typography,
+} from '@mui/material';
+
+export default function Approvals() {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/approvals')
+      .then((res) => {
+        if (!res.ok) throw new Error('Network response was not ok');
+        return res.json();
+      })
+      .then((json) => setData(json))
+      .catch((err) => setError(err))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <CircularProgress />;
+  if (error) return <Alert severity="error">Error: {error.message}</Alert>;
+
+  return (
+    <>
+      <Typography variant="h4" gutterBottom>
+        Approvals
+      </Typography>
+      <List>
+        {data.map((item, idx) => (
+          <ListItem key={idx}>{JSON.stringify(item)}</ListItem>
+        ))}
+      </List>
+    </>
+  );
+}

--- a/frontend/src/pages/PurchaseOrders.jsx
+++ b/frontend/src/pages/PurchaseOrders.jsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import {
+  CircularProgress,
+  Alert,
+  List,
+  ListItem,
+  Typography,
+} from '@mui/material';
+
+export default function PurchaseOrders() {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/orders')
+      .then((res) => {
+        if (!res.ok) throw new Error('Network response was not ok');
+        return res.json();
+      })
+      .then((json) => setData(json))
+      .catch((err) => setError(err))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <CircularProgress />;
+  if (error) return <Alert severity="error">Error: {error.message}</Alert>;
+
+  return (
+    <>
+      <Typography variant="h4" gutterBottom>
+        Purchase Orders
+      </Typography>
+      <List>
+        {data.map((item, idx) => (
+          <ListItem key={idx}>{JSON.stringify(item)}</ListItem>
+        ))}
+      </List>
+    </>
+  );
+}

--- a/frontend/src/pages/RequestsList.jsx
+++ b/frontend/src/pages/RequestsList.jsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import {
+  CircularProgress,
+  Alert,
+  List,
+  ListItem,
+  Typography,
+} from '@mui/material';
+
+export default function RequestsList() {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/requests')
+      .then((res) => {
+        if (!res.ok) throw new Error('Network response was not ok');
+        return res.json();
+      })
+      .then((json) => setData(json))
+      .catch((err) => setError(err))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <CircularProgress />;
+  if (error) return <Alert severity="error">Error: {error.message}</Alert>;
+
+  return (
+    <>
+      <Typography variant="h4" gutterBottom>
+        Requests
+      </Typography>
+      <List>
+        {data.map((item, idx) => (
+          <ListItem key={idx}>{JSON.stringify(item)}</ListItem>
+        ))}
+      </List>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace Hello World with a Material UI navigation bar and React Router
- Add Requests, Approvals, and Orders pages that fetch API data with loading/error states

## Testing
- `npm run lint`
- `npm run format`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c61b2a3e3c832ab9444b4c2ad1bd5b