### PR TITLE
Add unit tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,30 +4,17 @@ on:
   pull_request:
 
 jobs:
-  backend:
+  test:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: backend
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm ci
-      - run: npm run lint
-      - run: npm test
-
-  frontend:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - run: npm ci
+      - name: Install dependencies
+        run: |
+          npm ci
+          npm --prefix backend ci
+          npm --prefix frontend ci
       - run: npm run lint
       - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # ProcurementsManagement
 A procurement management website.
+
+## Running Tests
+
+Install dependencies for the root project and both sub-projects:
+
+```bash
+npm install
+npm --prefix backend install
+npm --prefix frontend install
+```
+
+Run the test suite:
+
+```bash
+npm test
+```
+
+This will execute backend Jest tests and frontend Vitest tests.

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,12 +5,16 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^7.1.1"
   }
 }

--- a/backend/test/app.test.js
+++ b/backend/test/app.test.js
@@ -1,0 +1,10 @@
+const request = require('supertest');
+const app = require('../index');
+
+describe('GET /', () => {
+  it('responds with greeting', async () => {
+    const res = await request(app).get('/');
+    expect(res.statusCode).toBe(200);
+    expect(res.text).toBe('Hello World from backend!');
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest"
   },
   "keywords": [],
   "author": "",
@@ -18,6 +18,10 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.0",
-    "vite": "^5.4.0"
+    "vite": "^5.4.0",
+    "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/react": "^14.2.1",
+    "jsdom": "^24.0.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import App from './App.jsx';
+
+test('renders greeting', () => {
+  render(<App />);
+  expect(screen.getByText(/Hello World from frontend!/i)).toBeInTheDocument();
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,4 +3,7 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+  },
 });

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint backend",
     "format": "prettier --check backend frontend",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npm --prefix backend test && npm --prefix frontend test"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add Jest tests for Express backend route
- add Vitest tests for React frontend component
- run lint and tests in GitHub Actions
- document how to run tests locally

## Testing
- `npm run lint`
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c61b2b0500832aa7a4304bff42e13f