### PR TITLE
feat: set up express server

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,35 +1,43 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a/backend/index.js b/backend/index.js
-index ccf42fb7512c2ca1231e5eab1efd7a03489f28f0..7ea2bed03d8098d01bee321349451d7bb1470e18 100644
---- a/backend/index.js
-+++ b/backend/index.js
-@@ -1,13 +1,23 @@
- const express = require('express');
- const app = express();
- 
--app.get('/', (req, res) => {
--  res.send('Hello World from backend!');
--});
-+const authRoutes = require('./routes/auth');
-+const procurementRoutes = require('./routes/procurements');
-+const { authenticate, authorize } = require('./middleware/auth');
-+
-+app.use(express.json());
-+
-+app.use('/auth', authRoutes);
-+app.use(
-+  '/procurements',
-+  authenticate,
-+  authorize(['Finance', 'Requester', 'Buyer', 'Approver', 'Admin']),
-+  procurementRoutes
-+);
- 
- const port = process.env.PORT || 3000;
- app.listen(port, () => {
-   console.log(`Server running on port ${port}`);
- });
- 
- module.exports = app;
- 
-EOF
-)
+const express = require('express');
+const authRoutes = require('./routes/auth');
+const requestRoutes = require('./routes/requests');
+const approvalRoutes = require('./routes/approvals');
+const orderRoutes = require('./routes/orders');
+const { authenticate, authorize } = require('./middleware/auth');
+
+const app = express();
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.json({ message: 'Procurement Management backend is running' });
+});
+
+app.use('/auth', authRoutes);
+
+app.use(
+  '/api/requests',
+  authenticate,
+  authorize(['Finance', 'Requester', 'Buyer', 'Approver', 'Admin']),
+  requestRoutes
+);
+
+app.use(
+  '/api/approvals',
+  authenticate,
+  authorize(['Finance', 'Requester', 'Buyer', 'Approver', 'Admin']),
+  approvalRoutes
+);
+
+app.use(
+  '/api/orders',
+  authenticate,
+  authorize(['Finance', 'Requester', 'Buyer', 'Approver', 'Admin']),
+  orderRoutes
+);
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});
+
+module.exports = app;


### PR DESCRIPTION
## Summary
- replace patch text in backend/index.js with working Express server
- expose auth routes and API routes for requests, approvals, and orders
- add simple root health check

## Testing
- `npm run lint`
- `npm run format` (fails: backend/package.json has invalid JSON)
- `npm test` (fails: backend/package.json has invalid JSON)


------
https://chatgpt.com/codex/tasks/task_e_68c620908f84832a92df44db5dfd6a78