### PR TITLE
test: render App within router

### DIFF
--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,8 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
 import App from './App.jsx';
 
-test('renders greeting', () => {
-  render(<App />);
-  expect(screen.getByText(/Hello World from frontend!/i)).toBeInTheDocument();
+test('renders Requests navigation button', () => {
+  render(
+    <MemoryRouter>
+      <App />
+    </MemoryRouter>
+  );
+  expect(screen.getByRole('button', { name: /requests/i })).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- ensure `App` test renders within router context
- assert the Requests navigation button is present

## Testing
- `npm test` *(fails: Invalid package.json in backend)*
- `npm --prefix frontend test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c62092a2dc832ab6916b435b055813