### PR TITLE
Refactor purchase orders page styling

### DIFF
--- a/frontend/src/pages/PurchaseOrders.jsx
+++ b/frontend/src/pages/PurchaseOrders.jsx
@@ -1,41 +1,219 @@
-import { useEffect, useState } from 'react';
-import {
-  CircularProgress,
-  Alert,
-  List,
-  ListItem,
-  Typography,
-} from '@mui/material';
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Card, CardBody, CardHeader } from "../components/Card";
+import { T, Th, Td } from "../components/Table";
+import Button from "../components/Button";
+import Badge from "../components/Badge";
+import SkeletonRow from "../components/SkeletonRow";
+import { apiGet } from "../lib/api";
 
 export default function PurchaseOrders() {
-  const [data, setData] = useState([]);
+  const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const [error, setError] = useState("");
+  const [search, setSearch] = useState("");
 
-  useEffect(() => {
-    fetch('/api/orders')
-      .then((res) => {
-        if (!res.ok) throw new Error('Network response was not ok');
-        return res.json();
-      })
-      .then((json) => setData(json))
-      .catch((err) => setError(err))
-      .finally(() => setLoading(false));
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const data = await apiGet("/api/orders");
+      setOrders(Array.isArray(data) ? data : []);
+    } catch (e) {
+      setOrders([]);
+      setError(e?.message || "Unable to fetch purchase orders.");
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  if (loading) return <CircularProgress />;
-  if (error) return <Alert severity="error">Error: {error.message}</Alert>;
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const filtered = useMemo(() => {
+    const list = Array.isArray(orders) ? orders : [];
+    const term = search.trim().toLowerCase();
+    if (!term) return list;
+    return list.filter((order) => {
+      const values = [
+        pickField(order, ["po_number", "poNumber", "number", "id"]),
+        pickField(order, ["vendor_name", "vendor", "vendorName"]),
+        pickField(order, ["status", "state", "stage"]),
+        pickField(order, ["total", "amount", "value"]),
+        pickField(order, ["request_id", "requestId"]),
+        JSON.stringify(order || {}),
+      ];
+      return values.some((value) =>
+        value && value.toString().toLowerCase().includes(term)
+      );
+    });
+  }, [orders, search]);
+
+  const emptyMessage = orders.length
+    ? "No purchase orders match your search."
+    : "No purchase orders yet.";
 
   return (
-    <>
-      <Typography variant="h4" gutterBottom>
-        Purchase Orders
-      </Typography>
-      <List>
-        {data.map((item, idx) => (
-          <ListItem key={idx}>{JSON.stringify(item)}</ListItem>
-        ))}
-      </List>
-    </>
+    <div className="space-y-4">
+      <Card>
+        <CardHeader
+          title="Purchase orders"
+          subtitle="Monitor issued POs and vendor fulfilment"
+          actions={(
+            <div className="flex items-center gap-2">
+              <input
+                className="w-56 rounded-lg border px-3 py-2 text-sm"
+                placeholder="Search PO, vendor, status…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+              <Button variant="ghost" onClick={load} disabled={loading}>
+                Refresh
+              </Button>
+            </div>
+          )}
+        />
+        <CardBody className="p-0">
+          {error && (
+            <div className="border-b border-red-200 bg-red-50/90 px-5 py-3 text-sm text-red-600">
+              Failed to load purchase orders: {error}
+            </div>
+          )}
+          <div className="overflow-x-auto rounded-2xl">
+            <T>
+              <thead className="bg-slate-50">
+                <tr className="border-b border-slate-100">
+                  <Th align="left">PO #</Th>
+                  <Th align="left">Vendor</Th>
+                  <Th align="right">Total</Th>
+                  <Th align="center">Status</Th>
+                  <Th align="left">Updated</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading &&
+                  Array.from({ length: 5 }).map((_, i) => (
+                    <SkeletonRow key={i} cols={5} />
+                  ))}
+                {!loading &&
+                  filtered.map((order, idx) => {
+                    const key =
+                      order?.id ??
+                      order?.po_number ??
+                      order?.poNumber ??
+                      order?.number ??
+                      idx;
+                    const poNumber =
+                      pickField(order, ["po_number", "poNumber", "number", "id"]) || "—";
+                    const requestId = pickField(order, ["request_id", "requestId"]);
+                    const vendorName =
+                      pickField(order, ["vendor_name", "vendor", "vendorName"]) || "—";
+                    const vendorId = pickField(order, ["vendor_id", "vendorId"]);
+                    const totalRaw = pickField(order, ["total", "amount", "value"]);
+                    const total = formatCurrency(totalRaw);
+                    const rawStatus = pickField(order, ["status", "state", "stage"]);
+                    const status = rawStatus
+                      ? rawStatus.toString().toLowerCase()
+                      : "";
+                    const updatedRaw = pickField(order, [
+                      "updated_at",
+                      "updatedAt",
+                      "created_at",
+                      "createdAt",
+                      "date",
+                      "issued_at",
+                      "issuedAt",
+                    ]);
+                    const updated = formatDate(updatedRaw);
+                    const dueRaw = pickField(order, [
+                      "expected_date",
+                      "expectedDate",
+                      "due_at",
+                      "dueAt",
+                      "due_date",
+                      "dueDate",
+                      "delivery_date",
+                      "deliveryDate",
+                    ]);
+                    const due = formatDate(dueRaw);
+
+                    return (
+                      <tr
+                        key={key}
+                        className="border-b border-slate-100 transition hover:bg-slate-50"
+                      >
+                        <Td>
+                          <div className="font-medium">{poNumber}</div>
+                          {requestId && (
+                            <div className="text-xs text-slate-500">
+                              Request #{requestId}
+                            </div>
+                          )}
+                        </Td>
+                        <Td>
+                          <div className="font-medium">{vendorName}</div>
+                          {vendorId && (
+                            <div className="text-xs text-slate-500">
+                              Vendor #{vendorId}
+                            </div>
+                          )}
+                        </Td>
+                        <Td align="right">{total}</Td>
+                        <Td align="center">
+                          <Badge status={status || undefined} />
+                        </Td>
+                        <Td>
+                          <div>{updated}</div>
+                          {dueRaw && (
+                            <div className="text-xs text-slate-500">
+                              Due {due}
+                            </div>
+                          )}
+                        </Td>
+                      </tr>
+                    );
+                  })}
+                {!loading && !filtered.length && (
+                  <tr>
+                    <Td colSpan="5" className="py-6 text-center text-slate-500">
+                      {emptyMessage}
+                    </Td>
+                  </tr>
+                )}
+              </tbody>
+            </T>
+          </div>
+        </CardBody>
+      </Card>
+    </div>
   );
+}
+
+function pickField(order, fields) {
+  for (const key of fields) {
+    const value = order?.[key];
+    if (value !== undefined && value !== null && value !== "") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function formatCurrency(value) {
+  if (value === undefined || value === null || value === "") return "—";
+  const num = Number(value);
+  if (!Number.isFinite(num)) return value;
+  return `$${num.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function formatDate(value) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleDateString();
 }


### PR DESCRIPTION
## Summary
- refactor the purchase orders page to use the shared card, table, and button primitives instead of Material UI widgets
- add search, refresh, and status formatting so purchase order data follows the app’s Tailwind-based design system
- include loading skeletons, inline error messaging, and helpers for currency/date formatting for consistent presentation

## Testing
- npm --prefix frontend test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68ccc96c00bc832a9abbb01110862197