### PR TITLE
Add auth bootstrap and guard for app routes

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,10 +2,14 @@ import { Outlet, NavLink, useLocation } from "react-router-dom";
 import { LogOut, ShoppingCart, CheckSquare, Settings as Cog, LayoutGrid, LogIn, UserPlus } from "lucide-react";
 import { AnimatePresence, motion } from "framer-motion";
 import ThemeToggle from "./components/ThemeToggle";
+import { useAuth } from "./lib/auth";
 
 export default function App() {
-  const user = JSON.parse(localStorage.getItem('user') || 'null');
-  function logout(){ localStorage.removeItem('token'); localStorage.removeItem('user'); location.href="/login"; }
+  const { user, logout: signOut } = useAuth();
+
+  function handleLogout() {
+    signOut();
+  }
 
   return (
     <div className="min-h-screen gradient-hero text-slate-900 grid md:grid-cols-[240px_1fr]">
@@ -23,7 +27,7 @@ export default function App() {
           {user ? (
             <div className="flex items-center justify-between text-sm">
               <div className="text-slate-600 truncate max-w-[140px]">{user.email}</div>
-              <button onClick={logout} className="inline-flex items-center gap-1 text-slate-700 hover:text-slate-900 press"><LogOut size={16}/> Logout</button>
+              <button onClick={handleLogout} className="inline-flex items-center gap-1 text-slate-700 hover:text-slate-900 press"><LogOut size={16}/> Logout</button>
             </div>
           ) : (
             <div className="flex items-center justify-between text-sm">

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -2,12 +2,24 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 import App from './App.jsx';
+import { AuthContext } from './lib/auth.jsx';
 
 test('renders Requests navigation button', () => {
+  const authValue = {
+    user: { id: 1, email: 'user@example.com', role: 'admin' },
+    status: 'authenticated',
+    setSession: () => {},
+    logout: () => {},
+    bootstrap: () => {},
+  };
+
   render(
-    <MemoryRouter>
-      <App />
-    </MemoryRouter>
+    <AuthContext.Provider value={authValue}>
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    </AuthContext.Provider>
   );
-  expect(screen.getByRole('link', { name: /requests/i })).toBeInTheDocument();
+  const requestLinks = screen.getAllByRole('link', { name: /requests/i });
+  expect(requestLinks.length).toBeGreaterThan(0);
 });

--- a/frontend/src/lib/auth.jsx
+++ b/frontend/src/lib/auth.jsx
@@ -1,0 +1,94 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { apiGet } from "./api";
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+  const [status, setStatus] = useState("checking");
+  const bootstrapping = useRef(false);
+
+  const setSession = useCallback((token, nextUser) => {
+    if (token && nextUser) {
+      localStorage.setItem("token", token);
+      localStorage.setItem("user", JSON.stringify(nextUser));
+      setUser(nextUser);
+      setStatus("authenticated");
+    } else {
+      localStorage.removeItem("token");
+      localStorage.removeItem("user");
+      setUser(null);
+      setStatus("unauthenticated");
+    }
+  }, []);
+
+  const bootstrap = useCallback(async () => {
+    if (bootstrapping.current) return;
+    bootstrapping.current = true;
+    const storedToken = localStorage.getItem("token");
+    if (!storedToken) {
+      setSession(null, null);
+      bootstrapping.current = false;
+      return;
+    }
+    setStatus((prev) => (prev === "authenticated" ? prev : "checking"));
+    try {
+      const data = await apiGet("/api/me");
+      if (data && data.user) {
+        setSession(storedToken, data.user);
+      } else {
+        throw new Error("missing user");
+      }
+    } catch (err) {
+      console.warn("Session bootstrap failed", err);
+      setSession(null, null);
+    } finally {
+      bootstrapping.current = false;
+    }
+  }, [setSession]);
+
+  useEffect(() => {
+    bootstrap();
+  }, [bootstrap]);
+
+  const logout = useCallback(() => {
+    setSession(null, null);
+  }, [setSession]);
+
+  const value = useMemo(
+    () => ({ user, status, setSession, logout, bootstrap }),
+    [user, status, setSession, logout, bootstrap]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within an AuthProvider");
+  return ctx;
+}
+
+export function RequireAuth({ children }) {
+  const { status, user } = useAuth();
+  const location = useLocation();
+
+  if (status === "checking") {
+    return (
+      <div className="min-h-screen gradient-hero flex items-center justify-center text-sm text-slate-500">
+        <div className="rounded-2xl border border-slate-200/80 bg-white/80 px-6 py-4 shadow-sm">
+          Verifying session…
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace state={{ from: location.pathname + location.search }} />;
+  }
+
+  return children;
+}
+
+export { AuthContext };

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -12,24 +12,34 @@ import Settings from "./pages/Settings";
 import Vendors from "./pages/Vendors";
 import Login from "./pages/Login";
 import Signup from "./pages/Signup";
+import { AuthProvider, RequireAuth } from "./lib/auth";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Landing />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/signup" element={<Signup />} />
-        <Route path="/app" element={<App />}>
-          <Route index element={<Dashboard />} />
-          <Route path="requests" element={<Requests />}>
-            <Route path=":id" element={<RequestDetailRoute />} />
+      <AuthProvider>
+        <Routes>
+          <Route path="/" element={<Landing />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/signup" element={<Signup />} />
+          <Route
+            path="/app"
+            element={(
+              <RequireAuth>
+                <App />
+              </RequireAuth>
+            )}
+          >
+            <Route index element={<Dashboard />} />
+            <Route path="requests" element={<Requests />}>
+              <Route path=":id" element={<RequestDetailRoute />} />
+            </Route>
+            <Route path="approvals" element={<Approvals />} />
+            <Route path="settings" element={<Settings />} />
+            <Route path="vendors" element={<Vendors />} />
           </Route>
-          <Route path="approvals" element={<Approvals />} />
-          <Route path="settings" element={<Settings />} />
-          <Route path="vendors" element={<Vendors />} />
-        </Route>
-      </Routes>
+        </Routes>
+      </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import AuthLayout from "../components/AuthLayout";
 import { apiPost } from "../lib/api";
+import { useAuth } from "../lib/auth";
 
 const inputClass =
   "w-full rounded-2xl border border-slate-200/80 bg-white/90 px-4 py-3 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-4 focus:ring-blue-200/50";
@@ -35,6 +36,9 @@ export default function Login() {
   const [err, setErr] = useState("");
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
+  const { setSession } = useAuth();
+  const redirectTo = location.state?.from || "/app";
 
   async function submit(e) {
     e.preventDefault();
@@ -42,9 +46,8 @@ export default function Login() {
     setLoading(true);
     try {
       const { token, user } = await apiPost("/api/auth/login", { email, password });
-      localStorage.setItem("token", token);
-      localStorage.setItem("user", JSON.stringify(user));
-      navigate("/app", { replace: true });
+      setSession(token, user);
+      navigate(redirectTo, { replace: true });
     } catch {
       setErr("Invalid email or password. Please try again.");
     } finally {

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import AuthLayout from "../components/AuthLayout";
 import { apiPost } from "../lib/api";
+import { useAuth } from "../lib/auth";
 
 const inputClass =
   "w-full rounded-2xl border border-slate-200/80 bg-white/90 px-4 py-3 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-4 focus:ring-blue-200/50";
@@ -58,6 +59,7 @@ export default function Signup() {
   const [err, setErr] = useState("");
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+  const { setSession } = useAuth();
 
   async function submit(e) {
     e.preventDefault();
@@ -73,8 +75,7 @@ export default function Signup() {
     setLoading(true);
     try {
       const res = await apiPost("/api/auth/signup", { email, password, role: "admin" });
-      localStorage.setItem("token", res.token);
-      localStorage.setItem("user", JSON.stringify(res.user));
+      setSession(res.token, res.user);
       navigate("/app", { replace: true });
     } catch (e) {
       const msg = String(e.message || "").includes("409")


### PR DESCRIPTION
## Summary
- add an AuthProvider/RequireAuth pair that bootstraps the saved token against /api/me before exposing the app shell
- wrap the /app routes with the new guard and update App to consume the context-provided session/logout helpers
- update login/signup flows and existing tests to drive the new session management API

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68ccc9609d74832a9ebc79c259f1de7b