### PR TITLE
Wire marketing landing to live procurement data

### DIFF
--- a/backend/migrations/013_marketing_role_profiles.sql
+++ b/backend/migrations/013_marketing_role_profiles.sql
@@ -1,0 +1,76 @@
+CREATE TABLE IF NOT EXISTS marketing_role_profiles (
+  id SERIAL PRIMARY KEY,
+  role_id TEXT UNIQUE NOT NULL,
+  label TEXT NOT NULL,
+  headline TEXT NOT NULL,
+  summary TEXT NOT NULL,
+  responsibilities JSONB NOT NULL DEFAULT '[]'::jsonb,
+  cadence JSONB NOT NULL DEFAULT '[]'::jsonb,
+  tools JSONB NOT NULL DEFAULT '[]'::jsonb,
+  display_order INTEGER NOT NULL DEFAULT 0,
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO marketing_role_profiles
+  (role_id, label, headline, summary, responsibilities, cadence, tools, display_order)
+VALUES
+  (
+    'admin',
+    'Admin',
+    'Keep the workspace healthy',
+    'Admins maintain automations, integrations, and access so every team works from the same source of truth.',
+    '["Monitor automation runs and resolve sync failures before business hours.","Audit ERP, HRIS, and SSO connections weekly for accuracy.","Document configuration changes and communicate to stakeholders."]'::jsonb,
+    '["Daily: review the health console for warnings.","Weekly: align with security on access changes.","Quarterly: certify retention and archival policies."]'::jsonb,
+    '["Automation monitor","Configuration register","Access review"]'::jsonb,
+    10
+  ),
+  (
+    'finance',
+    'Finance',
+    'Steer spend with live visibility',
+    'Finance ensures budget coverage, forecasts impact, and keeps commitments aligned to plan.',
+    '["Validate cost center and GL coding on new intake.","Highlight variance risks and partner with budget owners.","Track committed spend and accruals using the live ledger."]'::jsonb,
+    '["Daily: clear approvals that meet guardrails.","Weekly: reconcile commitments with accounting.","Monthly: review renewal savings opportunities."]'::jsonb,
+    '["Commitments ledger","Approval console","Variance brief"]'::jsonb,
+    20
+  ),
+  (
+    'buyer',
+    'Buyer',
+    'Move sourcing work forward',
+    'Buyers manage diligence, negotiations, and stakeholder updates with a single shared timeline.',
+    '["Keep request status current with supplier and stakeholder actions.","Coordinate legal and security deliverables in the dossier.","Capture performance notes for quarterly business reviews."]'::jsonb,
+    '["Daily: update progress and outstanding tasks.","Weekly: align with finance on leverage and savings.","Quarterly: refresh preferred supplier recommendations."]'::jsonb,
+    '["Sourcing workroom","Supplier directory","Document vault"]'::jsonb,
+    30
+  ),
+  (
+    'approver',
+    'Approver',
+    'Decide quickly with context',
+    'Approvers receive a concise brief—budget, risk, legal status—so decisions are fast and defensible.',
+    '["Review the approval brief and flag follow-ups inside the record.","Ensure delegation coverage during travel and quarter-close.","Log conditions so procurement can operationalise them."]'::jsonb,
+    '["Daily: clear pending approvals grouped by priority.","Weekly: sync with procurement on escalations.","Quarterly: refresh delegation rules and playbooks."]'::jsonb,
+    '["Approval brief","Policy library","Delegation planner"]'::jsonb,
+    40
+  ),
+  (
+    'requester',
+    'Requester',
+    'Submit and follow with clarity',
+    'Requesters provide business cases, respond to clarifications, and track progress without leaving the workspace.',
+    '["Complete guided intake with supporting documentation and stakeholders.","Respond promptly to questions from procurement or security.","Plan renewals early with the reminders and budget coordination tools."]'::jsonb,
+    '["As needed: start intake before spend occurs.","During review: stay active in the request thread.","Post approval: confirm delivery and capture feedback."]'::jsonb,
+    '["Guided request","Tracking board","Renewal planner"]'::jsonb,
+    50
+  )
+ON CONFLICT (role_id) DO UPDATE
+SET
+  label = EXCLUDED.label,
+  headline = EXCLUDED.headline,
+  summary = EXCLUDED.summary,
+  responsibilities = EXCLUDED.responsibilities,
+  cadence = EXCLUDED.cadence,
+  tools = EXCLUDED.tools,
+  display_order = EXCLUDED.display_order,
+  updated_at = NOW();

--- a/backend/server.js
+++ b/backend/server.js
@@ -14,8 +14,7 @@ const {
 } = require('./workflow');
 
 const app = express();
-const extendExtraRoutes = require('./routes.extras');
-const extendRoutes = require('./routes.extras');
+const extraRoutes = require('./routes.extras');
 app.use(cors());
 app.use(express.json());
 
@@ -593,11 +592,12 @@ app.get('/api/requests/:id/files', authRequired, async (req, res) => {
   res.json(rows);
 });
 
-extendRoutes(app, pool, authRequired, roleRequired);
-if (extendExtraRoutes.extendComments)
-  extendExtraRoutes.extendComments(app, pool, authRequired);
-if (typeof extendRoutes === 'function')
-  extendRoutes(app, pool, authRequired, roleRequired);
+if (typeof extraRoutes === 'function')
+  extraRoutes(app, pool, authRequired, roleRequired);
+else if (extraRoutes && typeof extraRoutes.extend === 'function')
+  extraRoutes.extend(app, pool, authRequired, roleRequired);
+if (extraRoutes && typeof extraRoutes.extendComments === 'function')
+  extraRoutes.extendComments(app, pool, authRequired);
 app.listen(PORT, () =>
   console.log(`Backend listening on http://localhost:${PORT}`)
 );

--- a/backend/server.js
+++ b/backend/server.js
@@ -7,109 +7,408 @@ const jwt = require('jsonwebtoken');
 const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
-const { pickRule, materializeStages, recomputeRequestStatus } = require('./workflow');
+const {
+  pickRule,
+  materializeStages,
+  recomputeRequestStatus,
+} = require('./workflow');
 
 const app = express();
-const extendExtraRoutes = require("./routes.extras");
-const extendRoutes = require("./routes.extras");
+const extendExtraRoutes = require('./routes.extras');
+const extendRoutes = require('./routes.extras');
 app.use(cors());
 app.use(express.json());
 
 const PORT = process.env.PORT || 4000;
 const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-change-me';
 
-const conn = process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/procurement_db';
+const conn =
+  process.env.DATABASE_URL ||
+  'postgres://postgres:postgres@localhost:5432/procurement_db';
 const needsSSL = /render\.com|sslmode=require/i.test(conn);
-const pool = new Pool({ connectionString: conn, ssl: needsSSL ? { rejectUnauthorized: false } : false });
+const pool = new Pool({
+  connectionString: conn,
+  ssl: needsSSL ? { rejectUnauthorized: false } : false,
+});
 
-app.use((req, _res, next) => { console.log(`[API] ${req.method} ${req.url}`); next(); });
+app.use((req, _res, next) => {
+  console.log(`[API] ${req.method} ${req.url}`);
+  next();
+});
 
 const UPLOAD_DIR = path.join(__dirname, 'uploads');
 if (!fs.existsSync(UPLOAD_DIR)) fs.mkdirSync(UPLOAD_DIR, { recursive: true });
 app.use('/uploads', express.static(UPLOAD_DIR));
 const upload = multer({ dest: UPLOAD_DIR });
 
-// ===== auth helpers =====
-function signToken(user) { return jwt.sign({ id:user.id, email:user.email, role:user.role }, JWT_SECRET, { expiresIn:'7d' }); }
-function authRequired(req, res, next) {
-  const h = req.headers.authorization || ''; const token = h.startsWith('Bearer ')? h.slice(7): null;
-  if (!token) return res.status(401).json({ error:'missing token' });
-  try { req.user = jwt.verify(token, JWT_SECRET); next(); } catch { return res.status(401).json({ error:'invalid token' }); }
+function formatCurrency(amount) {
+  const value = Number(amount) || 0;
+  if (value >= 1_000_000_000) return `$${(value / 1_000_000_000).toFixed(1)}B`;
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `$${(value / 1_000).toFixed(1)}K`;
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: value >= 100 ? 0 : 2,
+  }).format(value);
 }
-function roleRequired(...roles){
-  return (req,res,next)=> (req.user && roles.includes(req.user.role)) ? next() : res.status(403).json({ error:'forbidden' });
+
+function formatCycleTime(hours) {
+  if (hours === null || Number.isNaN(hours)) return '—';
+  if (hours >= 24) return `${(hours / 24).toFixed(1)} days`;
+  return `${hours.toFixed(1)} hrs`;
+}
+
+function formatPercent(ratio) {
+  if (ratio === null || Number.isNaN(ratio)) return '—';
+  return `${(ratio * 100).toFixed(1)}%`;
+}
+
+function pluralize(value, singular, plural) {
+  const count = Number(value) || 0;
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function toTitle(value) {
+  if (!value) return '';
+  return String(value)
+    .split(/[\s_]+/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+// ===== auth helpers =====
+function signToken(user) {
+  return jwt.sign(
+    { id: user.id, email: user.email, role: user.role },
+    JWT_SECRET,
+    { expiresIn: '7d' }
+  );
+}
+function authRequired(req, res, next) {
+  const h = req.headers.authorization || '';
+  const token = h.startsWith('Bearer ') ? h.slice(7) : null;
+  if (!token) return res.status(401).json({ error: 'missing token' });
+  try {
+    req.user = jwt.verify(token, JWT_SECRET);
+    next();
+  } catch {
+    return res.status(401).json({ error: 'invalid token' });
+  }
+}
+function roleRequired(...roles) {
+  return (req, res, next) =>
+    req.user && roles.includes(req.user.role)
+      ? next()
+      : res.status(403).json({ error: 'forbidden' });
 }
 
 // ===== auth routes =====
-app.post('/api/auth/signup', async (req,res)=>{
-  try{
-    const { email, password, role } = req.body||{};
-    if(!email||!password) return res.status(400).json({ error:'email and password required' });
+app.post('/api/auth/signup', async (req, res) => {
+  try {
+    const { email, password, role } = req.body || {};
+    if (!email || !password)
+      return res.status(400).json({ error: 'email and password required' });
     const hash = await bcrypt.hash(password, 10);
-    const r = await pool.query('INSERT INTO users(email,password_hash,role) VALUES($1,$2,$3) RETURNING id,email,role',
-      [String(email).toLowerCase(), hash, role && ['requester','approver','admin'].includes(role)? role: 'requester']);
-    const user=r.rows[0]; const token=signToken(user);
+    const r = await pool.query(
+      'INSERT INTO users(email,password_hash,role) VALUES($1,$2,$3) RETURNING id,email,role',
+      [
+        String(email).toLowerCase(),
+        hash,
+        role && ['requester', 'approver', 'admin'].includes(role)
+          ? role
+          : 'requester',
+      ]
+    );
+    const user = r.rows[0];
+    const token = signToken(user);
     res.status(201).json({ token, user });
-  }catch(e){ if(String(e.message).includes('duplicate')) return res.status(409).json({ error:'email taken' }); res.status(500).json({ error:'signup failed' }); }
+  } catch (e) {
+    if (String(e.message).includes('duplicate'))
+      return res.status(409).json({ error: 'email taken' });
+    res.status(500).json({ error: 'signup failed' });
+  }
 });
-app.post('/api/auth/login', async (req,res)=>{
-  try{
-    const { email,password }=req.body||{};
-    const r = await pool.query('SELECT * FROM users WHERE email=$1', [String(email).toLowerCase()]);
-    if(!r.rows.length) return res.status(401).json({ error:'invalid credentials' });
-    const u=r.rows[0]; const ok=await bcrypt.compare(password||'', u.password_hash);
-    if(!ok) return res.status(401).json({ error:'invalid credentials' });
-    res.json({ token:signToken(u), user:{ id:u.id, email:u.email, role:u.role }});
-  }catch(e){ res.status(500).json({ error:'login failed' }); }
+app.post('/api/auth/login', async (req, res) => {
+  try {
+    const { email, password } = req.body || {};
+    const r = await pool.query('SELECT * FROM users WHERE email=$1', [
+      String(email).toLowerCase(),
+    ]);
+    if (!r.rows.length)
+      return res.status(401).json({ error: 'invalid credentials' });
+    const u = r.rows[0];
+    const ok = await bcrypt.compare(password || '', u.password_hash);
+    if (!ok) return res.status(401).json({ error: 'invalid credentials' });
+    res.json({
+      token: signToken(u),
+      user: { id: u.id, email: u.email, role: u.role },
+    });
+  } catch (e) {
+    res.status(500).json({ error: 'login failed' });
+  }
 });
-app.get('/api/me', authRequired, (req,res)=> res.json({ user:{ id:req.user.id, email:req.user.email, role:req.user.role }}));
+app.get('/api/me', authRequired, (req, res) =>
+  res.json({
+    user: { id: req.user.id, email: req.user.email, role: req.user.role },
+  })
+);
 
 // ===== health =====
-app.get('/api/health', async (_req,res)=>{
-  try{ const r=await pool.query('SELECT 1 as ok'); res.json({ api:'ok', db:r.rows[0].ok===1?'ok':'unknown' }); }
-  catch(e){ res.status(500).json({ api:'ok', db:'error', error:e.message||'' }); }
+app.get('/api/health', async (_req, res) => {
+  try {
+    const r = await pool.query('SELECT 1 as ok');
+    res.json({ api: 'ok', db: r.rows[0].ok === 1 ? 'ok' : 'unknown' });
+  } catch (e) {
+    res.status(500).json({ api: 'ok', db: 'error', error: e.message || '' });
+  }
+});
+
+app.get('/api/marketing/landing', async (_req, res) => {
+  try {
+    const [
+      spendRes,
+      cycleRowsRes,
+      policyRes,
+      intakeRes,
+      approvalsRes,
+      renewalsRes,
+      roleProfilesRes,
+    ] = await Promise.all([
+      pool.query(
+        "SELECT COALESCE(SUM(amount),0) AS total_amount FROM requests WHERE status != 'denied'"
+      ),
+      pool.query(
+        `SELECT r.created_at, MAX(ra.acted_at) AS completed_at
+           FROM requests r
+           JOIN request_approvals ra ON ra.request_id = r.id
+          WHERE ra.acted_at IS NOT NULL
+          GROUP BY r.id`
+      ),
+      pool.query(
+        `SELECT
+            COUNT(*) FILTER (WHERE acted_at IS NOT NULL) AS completed,
+            COUNT(*) FILTER (WHERE status='approved' AND acted_at IS NOT NULL) AS approved
+           FROM request_approvals`
+      ),
+      pool.query(
+        `SELECT
+            COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '24 hours') AS recent,
+            COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '24 hours' AND status='pending') AS pending_recent
+           FROM requests`
+      ),
+      pool.query(
+        `SELECT
+            COUNT(*)::int AS approvals_today,
+            COALESCE(array_agg(DISTINCT role_required), '{}') AS roles
+           FROM request_approvals
+          WHERE status='approved'
+            AND acted_at >= date_trunc('day', NOW())`
+      ),
+      pool.query(
+        `SELECT
+            COUNT(*)::int AS upcoming,
+            COUNT(DISTINCT requester_id)::int AS owners
+           FROM requests
+          WHERE status='approved'
+            AND (created_at + INTERVAL '1 year') BETWEEN NOW() AND NOW() + INTERVAL '30 days'`
+      ),
+      pool.query(
+        `SELECT role_id, label, headline, summary, responsibilities, cadence, tools
+           FROM marketing_role_profiles
+          ORDER BY display_order, label`
+      ),
+    ]);
+
+    const totalSpend = Number(spendRes.rows[0]?.total_amount || 0);
+
+    const durations = cycleRowsRes.rows
+      .map((row) => {
+        const created = row.created_at ? new Date(row.created_at) : null;
+        const completed = row.completed_at ? new Date(row.completed_at) : null;
+        if (
+          !created ||
+          !completed ||
+          Number.isNaN(created.getTime()) ||
+          Number.isNaN(completed.getTime())
+        )
+          return null;
+        const diffHours =
+          (completed.getTime() - created.getTime()) / (1000 * 60 * 60);
+        return diffHours > 0 ? diffHours : null;
+      })
+      .filter((value) => value !== null)
+      .sort((a, b) => a - b);
+
+    let medianHours = null;
+    if (durations.length) {
+      const mid = Math.floor(durations.length / 2);
+      medianHours =
+        durations.length % 2 === 0
+          ? (durations[mid - 1] + durations[mid]) / 2
+          : durations[mid];
+    }
+
+    const completedApprovals = Number(policyRes.rows[0]?.completed || 0);
+    const approvedApprovals = Number(policyRes.rows[0]?.approved || 0);
+    const adherenceRatio = completedApprovals
+      ? approvedApprovals / completedApprovals
+      : null;
+
+    const recentIntake = Number(intakeRes.rows[0]?.recent || 0);
+    const pendingRecent = Number(intakeRes.rows[0]?.pending_recent || 0);
+
+    const approvalsToday = Number(approvalsRes.rows[0]?.approvals_today || 0);
+    const rolesToday = Array.isArray(approvalsRes.rows[0]?.roles)
+      ? approvalsRes.rows[0].roles.filter(Boolean)
+      : [];
+
+    const renewalsUpcoming = Number(renewalsRes.rows[0]?.upcoming || 0);
+    const renewalOwners = Number(renewalsRes.rows[0]?.owners || 0);
+
+    const heroMetrics = [
+      { label: 'Spend under management', value: formatCurrency(totalSpend) },
+      { label: 'Median cycle time', value: formatCycleTime(medianHours) },
+      { label: 'Policy adherence', value: formatPercent(adherenceRatio) },
+    ];
+
+    const focusSignals = [
+      {
+        label: 'New intake',
+        value: pluralize(recentIntake, 'request', 'requests'),
+        meta: pendingRecent
+          ? `${pluralize(pendingRecent, 'request awaiting review', 'requests awaiting review')}`
+          : 'All triaged',
+      },
+      {
+        label: 'Approvals today',
+        value: pluralize(approvalsToday, 'decision', 'decisions'),
+        meta: rolesToday.length
+          ? rolesToday.map(toTitle).join(' · ')
+          : 'No approvals yet',
+      },
+      {
+        label: 'Renewals in 30 days',
+        value: pluralize(renewalsUpcoming, 'vendor', 'vendors'),
+        meta: renewalOwners
+          ? `${pluralize(renewalOwners, 'owner assigned', 'owners assigned')}`
+          : 'No owners assigned',
+      },
+    ];
+
+    const roleViews = roleProfilesRes.rows.map((row) => ({
+      id: row.role_id,
+      label: row.label,
+      headline: row.headline,
+      summary: row.summary,
+      responsibilities: Array.isArray(row.responsibilities)
+        ? row.responsibilities
+        : [],
+      cadence: Array.isArray(row.cadence) ? row.cadence : [],
+      tools: Array.isArray(row.tools) ? row.tools : [],
+    }));
+
+    res.json({ heroMetrics, focusSignals, roleViews });
+  } catch (error) {
+    console.error('marketing landing error', error);
+    res.status(500).json({ error: 'failed to load marketing data' });
+  }
 });
 
 // ===== vendors =====
-app.get('/api/vendors', async (_req,res)=>{ const { rows }=await pool.query('SELECT * FROM vendors ORDER BY name'); res.json(rows); });
-app.post('/api/vendors', authRequired, roleRequired('admin'), async (req,res)=>{
-  const { name, risk='low', status='active', website, notes } = req.body || {};
-  if(!name) return res.status(400).json({ error:'name required' });
-  const { rows } = await pool.query(
-    'INSERT INTO vendors(name,risk,status,website,notes) VALUES($1,$2,$3,$4,$5) RETURNING *',
-    [name.trim(), risk, status, website||null, notes||null]
-  );
-  res.status(201).json(rows[0]);
-});
-
-// ===== categories (kept) =====
-app.get('/api/categories', async (_req,res)=>{ const { rows }=await pool.query('SELECT id,name,monthly_budget FROM categories ORDER BY name'); res.json(rows); });
-app.post('/api/categories', authRequired, roleRequired('admin','approver'), async (req,res)=>{
-  const { name, monthly_budget=0 } = req.body||{};
-  if(!name) return res.status(400).json({ error:'name required' });
-  const budget=Number(monthly_budget)||0;
-  const { rows }=await pool.query('INSERT INTO categories(name,monthly_budget) VALUES($1,$2) RETURNING *', [name.trim(), budget]);
-  res.status(201).json(rows[0]);
-});
-
-// ===== approval rules (policy data) =====
-app.get('/api/approval-rules', authRequired, roleRequired('admin'), async (_req,res)=>{
-  const { rows }=await pool.query('SELECT * FROM approval_rules WHERE active=true ORDER BY min_amount');
+app.get('/api/vendors', async (_req, res) => {
+  const { rows } = await pool.query('SELECT * FROM vendors ORDER BY name');
   res.json(rows);
 });
-app.post('/api/approval-rules', authRequired, roleRequired('admin'), async (req,res)=>{
-  const { name, min_amount=0, max_amount=null, category_id=null, vendor_id=null, stages=[] } = req.body||{};
-  if(!name || !Array.isArray(stages) || stages.length===0) return res.status(400).json({ error:'name & stages required' });
-  const { rows }=await pool.query(
-    'INSERT INTO approval_rules(name,min_amount,max_amount,category_id,vendor_id,stages,active) VALUES($1,$2,$3,$4,$5,$6,true) RETURNING *',
-    [name, Number(min_amount)||0, max_amount===null? null: Number(max_amount), category_id, vendor_id, JSON.stringify(stages)]
+app.post(
+  '/api/vendors',
+  authRequired,
+  roleRequired('admin'),
+  async (req, res) => {
+    const {
+      name,
+      risk = 'low',
+      status = 'active',
+      website,
+      notes,
+    } = req.body || {};
+    if (!name) return res.status(400).json({ error: 'name required' });
+    const { rows } = await pool.query(
+      'INSERT INTO vendors(name,risk,status,website,notes) VALUES($1,$2,$3,$4,$5) RETURNING *',
+      [name.trim(), risk, status, website || null, notes || null]
+    );
+    res.status(201).json(rows[0]);
+  }
+);
+
+// ===== categories (kept) =====
+app.get('/api/categories', async (_req, res) => {
+  const { rows } = await pool.query(
+    'SELECT id,name,monthly_budget FROM categories ORDER BY name'
   );
-  res.status(201).json(rows[0]);
+  res.json(rows);
 });
+app.post(
+  '/api/categories',
+  authRequired,
+  roleRequired('admin', 'approver'),
+  async (req, res) => {
+    const { name, monthly_budget = 0 } = req.body || {};
+    if (!name) return res.status(400).json({ error: 'name required' });
+    const budget = Number(monthly_budget) || 0;
+    const { rows } = await pool.query(
+      'INSERT INTO categories(name,monthly_budget) VALUES($1,$2) RETURNING *',
+      [name.trim(), budget]
+    );
+    res.status(201).json(rows[0]);
+  }
+);
+
+// ===== approval rules (policy data) =====
+app.get(
+  '/api/approval-rules',
+  authRequired,
+  roleRequired('admin'),
+  async (_req, res) => {
+    const { rows } = await pool.query(
+      'SELECT * FROM approval_rules WHERE active=true ORDER BY min_amount'
+    );
+    res.json(rows);
+  }
+);
+app.post(
+  '/api/approval-rules',
+  authRequired,
+  roleRequired('admin'),
+  async (req, res) => {
+    const {
+      name,
+      min_amount = 0,
+      max_amount = null,
+      category_id = null,
+      vendor_id = null,
+      stages = [],
+    } = req.body || {};
+    if (!name || !Array.isArray(stages) || stages.length === 0)
+      return res.status(400).json({ error: 'name & stages required' });
+    const { rows } = await pool.query(
+      'INSERT INTO approval_rules(name,min_amount,max_amount,category_id,vendor_id,stages,active) VALUES($1,$2,$3,$4,$5,$6,true) RETURNING *',
+      [
+        name,
+        Number(min_amount) || 0,
+        max_amount === null ? null : Number(max_amount),
+        category_id,
+        vendor_id,
+        JSON.stringify(stages),
+      ]
+    );
+    res.status(201).json(rows[0]);
+  }
+);
 
 // ===== requests with vendor, policy-driven stages =====
-app.get('/api/requests', async (_req,res)=>{
-  const { rows }=await pool.query(
+app.get('/api/requests', async (_req, res) => {
+  const { rows } = await pool.query(
     `SELECT r.id,r.title,r.amount,r.status,r.created_at,r.category_id,c.name AS category_name,
             r.vendor_id,v.name AS vendor_name, r.po_number
        FROM requests r
@@ -120,55 +419,86 @@ app.get('/api/requests', async (_req,res)=>{
   res.json(rows);
 });
 
-app.get('/api/requests/:id/approvals', authRequired, async (req,res)=>{
-  const { rows }=await pool.query('SELECT * FROM request_approvals WHERE request_id=$1 ORDER BY stage_index', [Number(req.params.id)]);
+app.get('/api/requests/:id/approvals', authRequired, async (req, res) => {
+  const { rows } = await pool.query(
+    'SELECT * FROM request_approvals WHERE request_id=$1 ORDER BY stage_index',
+    [Number(req.params.id)]
+  );
   res.json(rows);
 });
 
-app.post('/api/requests', authRequired, async (req,res)=>{
+app.post('/api/requests', authRequired, async (req, res) => {
   const client = await pool.connect();
-  try{
-    const { title, amount, category_id, vendor_id, po_number } = req.body||{};
-    if(!title) return res.status(400).json({ error:'title required' });
-    const amt = Number(amount); if(Number.isNaN(amt)||amt<0) return res.status(400).json({ error:'invalid amount' });
+  try {
+    const { title, amount, category_id, vendor_id, po_number } = req.body || {};
+    if (!title) return res.status(400).json({ error: 'title required' });
+    const amt = Number(amount);
+    if (Number.isNaN(amt) || amt < 0)
+      return res.status(400).json({ error: 'invalid amount' });
 
     await client.query('BEGIN');
     const ins = await client.query(
       `INSERT INTO requests(title,amount,category_id,requester_id,vendor_id,po_number)
        VALUES($1,$2,$3,$4,$5,$6)
        RETURNING id,title,amount,status,created_at,category_id,vendor_id,po_number`,
-      [title.trim(), amt, category_id||null, req.user.id, vendor_id||null, po_number||null]
+      [
+        title.trim(),
+        amt,
+        category_id || null,
+        req.user.id,
+        vendor_id || null,
+        po_number || null,
+      ]
     );
     const reqRow = ins.rows[0];
 
-    const rulesQ = await client.query('SELECT * FROM approval_rules WHERE active=true ORDER BY min_amount');
-    const rule = pickRule({ amount: amt, category_id: category_id||null, vendor_id: vendor_id||null, rules: rulesQ.rows });
+    const rulesQ = await client.query(
+      'SELECT * FROM approval_rules WHERE active=true ORDER BY min_amount'
+    );
+    const rule = pickRule({
+      amount: amt,
+      category_id: category_id || null,
+      vendor_id: vendor_id || null,
+      rules: rulesQ.rows,
+    });
     const stages = rule ? JSON.parse(rule.stages) : ['approver']; // fallback single approver
 
     await materializeStages(client, reqRow.id, stages);
     await client.query(
       'INSERT INTO audit_log(object_type, object_id, action, actor_id, meta) VALUES($1,$2,$3,$4,$5)',
-      ['request', reqRow.id, 'create', req.user.id, JSON.stringify({ amount: amt, category_id, vendor_id, po_number })]
+      [
+        'request',
+        reqRow.id,
+        'create',
+        req.user.id,
+        JSON.stringify({ amount: amt, category_id, vendor_id, po_number }),
+      ]
     );
     await client.query('COMMIT');
     res.status(201).json(reqRow);
-  }catch(e){
+  } catch (e) {
     await client.query('ROLLBACK');
     console.error('create request error:', e.message);
-    res.status(500).json({ error:'failed to create' });
-  }finally{ client.release(); }
+    res.status(500).json({ error: 'failed to create' });
+  } finally {
+    client.release();
+  }
 });
 
 // stage approve/deny (enforce role per stage)
-app.post('/api/requests/:id/approve', authRequired, async (req,res)=>{
+app.post('/api/requests/:id/approve', authRequired, async (req, res) => {
   const client = await pool.connect();
-  try{
+  try {
     const request_id = Number(req.params.id);
     await client.query('BEGIN');
-    const { rows: stages }=await client.query('SELECT * FROM request_approvals WHERE request_id=$1 ORDER BY stage_index FOR UPDATE', [request_id]);
-    const open = stages.find(s => s.status==='pending');
-    if(!open) return res.status(400).json({ error:'no pending stage' });
-    if(req.user.role !== open.role_required && req.user.role!=='admin') return res.status(403).json({ error:'wrong role for this stage' });
+    const { rows: stages } = await client.query(
+      'SELECT * FROM request_approvals WHERE request_id=$1 ORDER BY stage_index FOR UPDATE',
+      [request_id]
+    );
+    const open = stages.find((s) => s.status === 'pending');
+    if (!open) return res.status(400).json({ error: 'no pending stage' });
+    if (req.user.role !== open.role_required && req.user.role !== 'admin')
+      return res.status(403).json({ error: 'wrong role for this stage' });
 
     await client.query(
       'UPDATE request_approvals SET status=$1, acted_by=$2, acted_at=NOW() WHERE id=$3',
@@ -177,23 +507,37 @@ app.post('/api/requests/:id/approve', authRequired, async (req,res)=>{
     await recomputeRequestStatus(client, request_id);
     await client.query(
       'INSERT INTO audit_log(object_type,object_id,action,actor_id,meta) VALUES($1,$2,$3,$4,$5)',
-      ['request', request_id, 'approve', req.user.id, JSON.stringify({ stage_index: open.stage_index })]
+      [
+        'request',
+        request_id,
+        'approve',
+        req.user.id,
+        JSON.stringify({ stage_index: open.stage_index }),
+      ]
     );
     await client.query('COMMIT');
-    res.json({ ok:true });
-  }catch(e){ await client.query('ROLLBACK'); res.status(500).json({ error:'approve failed' }); }
-  finally{ client.release(); }
+    res.json({ ok: true });
+  } catch (e) {
+    await client.query('ROLLBACK');
+    res.status(500).json({ error: 'approve failed' });
+  } finally {
+    client.release();
+  }
 });
 
-app.post('/api/requests/:id/deny', authRequired, async (req,res)=>{
+app.post('/api/requests/:id/deny', authRequired, async (req, res) => {
   const client = await pool.connect();
-  try{
+  try {
     const request_id = Number(req.params.id);
     await client.query('BEGIN');
-    const { rows: stages }=await client.query('SELECT * FROM request_approvals WHERE request_id=$1 ORDER BY stage_index FOR UPDATE', [request_id]);
-    const open = stages.find(s => s.status==='pending');
-    if(!open) return res.status(400).json({ error:'no pending stage' });
-    if(req.user.role !== open.role_required && req.user.role!=='admin') return res.status(403).json({ error:'wrong role for this stage' });
+    const { rows: stages } = await client.query(
+      'SELECT * FROM request_approvals WHERE request_id=$1 ORDER BY stage_index FOR UPDATE',
+      [request_id]
+    );
+    const open = stages.find((s) => s.status === 'pending');
+    if (!open) return res.status(400).json({ error: 'no pending stage' });
+    if (req.user.role !== open.role_required && req.user.role !== 'admin')
+      return res.status(403).json({ error: 'wrong role for this stage' });
 
     await client.query(
       'UPDATE request_approvals SET status=$1, acted_by=$2, acted_at=NOW() WHERE id=$3',
@@ -202,32 +546,58 @@ app.post('/api/requests/:id/deny', authRequired, async (req,res)=>{
     await recomputeRequestStatus(client, request_id);
     await client.query(
       'INSERT INTO audit_log(object_type,object_id,action,actor_id,meta) VALUES($1,$2,$3,$4,$5)',
-      ['request', request_id, 'deny', req.user.id, JSON.stringify({ stage_index: open.stage_index })]
+      [
+        'request',
+        request_id,
+        'deny',
+        req.user.id,
+        JSON.stringify({ stage_index: open.stage_index }),
+      ]
     );
     await client.query('COMMIT');
-    res.json({ ok:true });
-  }catch(e){ await client.query('ROLLBACK'); res.status(500).json({ error:'deny failed' }); }
-  finally{ client.release(); }
+    res.json({ ok: true });
+  } catch (e) {
+    await client.query('ROLLBACK');
+    res.status(500).json({ error: 'deny failed' });
+  } finally {
+    client.release();
+  }
 });
 
 // files (keep)
-app.post('/api/requests/:id/files', authRequired, upload.single('file'), async (req,res)=>{
-  try{
-    const id = Number(req.params.id);
-    if(!req.file) return res.status(400).json({ error:'file required' });
-    const url = `/uploads/${req.file.filename}`;
-    const r = await pool.query('INSERT INTO request_files(request_id,filename,url) VALUES($1,$2,$3) RETURNING *',
-      [id, req.file.originalname, url]);
-    res.status(201).json(r.rows[0]);
-  }catch(e){ res.status(500).json({ error:'upload failed' }); }
-});
-app.get('/api/requests/:id/files', authRequired, async (req,res)=>{
+app.post(
+  '/api/requests/:id/files',
+  authRequired,
+  upload.single('file'),
+  async (req, res) => {
+    try {
+      const id = Number(req.params.id);
+      if (!req.file) return res.status(400).json({ error: 'file required' });
+      const url = `/uploads/${req.file.filename}`;
+      const r = await pool.query(
+        'INSERT INTO request_files(request_id,filename,url) VALUES($1,$2,$3) RETURNING *',
+        [id, req.file.originalname, url]
+      );
+      res.status(201).json(r.rows[0]);
+    } catch (e) {
+      res.status(500).json({ error: 'upload failed' });
+    }
+  }
+);
+app.get('/api/requests/:id/files', authRequired, async (req, res) => {
   const id = Number(req.params.id);
-  const { rows }=await pool.query('SELECT id,filename,url,created_at FROM request_files WHERE request_id=$1 ORDER BY created_at DESC', [id]);
+  const { rows } = await pool.query(
+    'SELECT id,filename,url,created_at FROM request_files WHERE request_id=$1 ORDER BY created_at DESC',
+    [id]
+  );
   res.json(rows);
 });
 
 extendRoutes(app, pool, authRequired, roleRequired);
-if (extendExtraRoutes.extendComments) extendExtraRoutes.extendComments(app, pool, authRequired);
-if (typeof extendRoutes === "function") extendRoutes(app, pool, authRequired, roleRequired);
-app.listen(PORT, ()=> console.log(`Backend listening on http://localhost:${PORT}`));
+if (extendExtraRoutes.extendComments)
+  extendExtraRoutes.extendComments(app, pool, authRequired);
+if (typeof extendRoutes === 'function')
+  extendRoutes(app, pool, authRequired, roleRequired);
+app.listen(PORT, () =>
+  console.log(`Backend listening on http://localhost:${PORT}`)
+);

--- a/frontend/src/pages/Landing.jsx
+++ b/frontend/src/pages/Landing.jsx
@@ -1,237 +1,229 @@
-import { useState } from "react";
+import { useEffect, useState } from 'react';
+import { apiGet } from '../lib/api';
 
 const navLinks = [
-  { label: "Overview", href: "#overview" },
-  { label: "Program", href: "#program" },
-  { label: "Roles", href: "#roles" },
-  { label: "Resources", href: "#resources" },
-  { label: "Access", href: "#access" },
+  { label: 'Overview', href: '#overview' },
+  { label: 'Program', href: '#program' },
+  { label: 'Roles', href: '#roles' },
+  { label: 'Resources', href: '#resources' },
+  { label: 'Access', href: '#access' },
 ];
 
-const heroMetrics = [
-  { label: "Spend under management", value: "$184M" },
-  { label: "Median cycle time", value: "3.4 days" },
-  { label: "Policy adherence", value: "99.2%" },
+const HERO_METRIC_TEMPLATE = [
+  { label: 'Spend under management', value: '—' },
+  { label: 'Median cycle time', value: '—' },
+  { label: 'Policy adherence', value: '—' },
 ];
 
-const focusSignals = [
-  { label: "New intake", value: "5 requests", meta: "Needs triage" },
-  { label: "Approvals today", value: "12 decisions", meta: "Finance · Legal" },
-  { label: "Renewals in 30 days", value: "3 vendors", meta: "Owners assigned" },
+const FOCUS_SIGNAL_TEMPLATE = [
+  { label: 'New intake', value: '—', meta: 'Loading' },
+  { label: 'Approvals today', value: '—', meta: 'Loading' },
+  { label: 'Renewals in 30 days', value: '—', meta: 'Loading' },
 ];
 
 const approvalsQueue = [
   {
-    name: "Marketing automation expansion",
-    owner: "Finance review",
-    status: "Due today",
+    name: 'Marketing automation expansion',
+    owner: 'Finance review',
+    status: 'Due today',
   },
   {
-    name: "Global payroll renewal",
-    owner: "Legal & security",
-    status: "Docs in progress",
+    name: 'Global payroll renewal',
+    owner: 'Legal & security',
+    status: 'Docs in progress',
   },
   {
-    name: "Data warehouse contract",
-    owner: "CFO approval",
-    status: "Next in queue",
+    name: 'Data warehouse contract',
+    owner: 'CFO approval',
+    status: 'Next in queue',
   },
 ];
 
 const programPillars = [
   {
-    title: "Intake discipline",
+    title: 'Intake discipline',
     summary:
-      "Guided intake captures business context, budgets, and risk posture before a request is routed.",
+      'Guided intake captures business context, budgets, and risk posture before a request is routed.',
     points: [
-      "Adaptive forms surface preferred suppliers and negotiated terms.",
-      "Critical fields validate instantly so no rework is required.",
-      "Stakeholders see a clean dossier from the first submission.",
+      'Adaptive forms surface preferred suppliers and negotiated terms.',
+      'Critical fields validate instantly so no rework is required.',
+      'Stakeholders see a clean dossier from the first submission.',
     ],
   },
   {
-    title: "Approvals in sequence",
+    title: 'Approvals in sequence',
     summary:
-      "Routing mirrors the delegation of authority so decisions move quickly without side channels.",
+      'Routing mirrors the delegation of authority so decisions move quickly without side channels.',
     points: [
-      "Finance, legal, and IT collaborate in-line with full context.",
-      "Exceptions and comments are preserved with the approval record.",
-      "Dashboards highlight blockers before they impact the business.",
+      'Finance, legal, and IT collaborate in-line with full context.',
+      'Exceptions and comments are preserved with the approval record.',
+      'Dashboards highlight blockers before they impact the business.',
     ],
   },
   {
-    title: "Vendor lifecycle",
+    title: 'Vendor lifecycle',
     summary:
-      "Supplier profiles hold contracts, obligations, performance, and renewal timelines in one workspace.",
+      'Supplier profiles hold contracts, obligations, performance, and renewal timelines in one workspace.',
     points: [
-      "Owners receive renewal runway alerts with playbooks attached.",
-      "Risk and compliance attestations stay audit-ready.",
-      "Quarterly business reviews are fed with live performance data.",
+      'Owners receive renewal runway alerts with playbooks attached.',
+      'Risk and compliance attestations stay audit-ready.',
+      'Quarterly business reviews are fed with live performance data.',
     ],
   },
 ];
 
 const rituals = [
   {
-    time: "08:30",
-    title: "Morning brief",
-    description: "Operations reviews new intake, flags blockers, and assigns first responses.",
+    time: '08:30',
+    title: 'Morning brief',
+    description:
+      'Operations reviews new intake, flags blockers, and assigns first responses.',
   },
   {
-    time: "11:00",
-    title: "Cross-functional stand-up",
-    description: "Finance, legal, and security sync on escalations directly in the workspace.",
+    time: '11:00',
+    title: 'Cross-functional stand-up',
+    description:
+      'Finance, legal, and security sync on escalations directly in the workspace.',
   },
   {
-    time: "15:00",
-    title: "Renewal sweep",
-    description: "Procurement owners confirm prep work for 30/60/90-day renewals.",
+    time: '15:00',
+    title: 'Renewal sweep',
+    description:
+      'Procurement owners confirm prep work for 30/60/90-day renewals.',
   },
   {
-    time: "Friday",
-    title: "Program review",
-    description: "Metrics, automation health, and policy updates are published to leadership.",
-  },
-];
-
-const roleViews = [
-  {
-    id: "admin",
-    label: "Admin",
-    headline: "Keep the workspace healthy",
-    summary:
-      "Admins maintain automations, integrations, and access so every team works from the same source of truth.",
-    responsibilities: [
-      "Monitor automation runs and resolve sync failures before business hours.",
-      "Audit ERP, HRIS, and SSO connections weekly for accuracy.",
-      "Document configuration changes and communicate to stakeholders.",
-    ],
-    cadence: [
-      "Daily: review the health console for warnings.",
-      "Weekly: align with security on access changes.",
-      "Quarterly: certify retention and archival policies.",
-    ],
-    tools: ["Automation monitor", "Configuration register", "Access review"],
-  },
-  {
-    id: "finance",
-    label: "Finance",
-    headline: "Steer spend with live visibility",
-    summary:
-      "Finance ensures budget coverage, forecasts impact, and keeps commitments aligned to plan.",
-    responsibilities: [
-      "Validate cost center and GL coding on new intake.",
-      "Highlight variance risks and partner with budget owners.",
-      "Track committed spend and accruals using the live ledger.",
-    ],
-    cadence: [
-      "Daily: clear approvals that meet guardrails.",
-      "Weekly: reconcile commitments with accounting.",
-      "Monthly: review renewal savings opportunities.",
-    ],
-    tools: ["Commitments ledger", "Approval console", "Variance brief"],
-  },
-  {
-    id: "buyer",
-    label: "Buyer",
-    headline: "Move sourcing work forward",
-    summary:
-      "Buyers manage diligence, negotiations, and stakeholder updates with a single shared timeline.",
-    responsibilities: [
-      "Keep request status current with supplier and stakeholder actions.",
-      "Coordinate legal and security deliverables in the dossier.",
-      "Capture performance notes for quarterly business reviews.",
-    ],
-    cadence: [
-      "Daily: update progress and outstanding tasks.",
-      "Weekly: align with finance on leverage and savings.",
-      "Quarterly: refresh preferred supplier recommendations.",
-    ],
-    tools: ["Sourcing workroom", "Supplier directory", "Document vault"],
-  },
-  {
-    id: "approver",
-    label: "Approver",
-    headline: "Decide quickly with context",
-    summary:
-      "Approvers receive a concise brief—budget, risk, legal status—so decisions are fast and defensible.",
-    responsibilities: [
-      "Review the approval brief and flag follow-ups inside the record.",
-      "Ensure delegation coverage during travel and quarter-close.",
-      "Log conditions so procurement can operationalise them.",
-    ],
-    cadence: [
-      "Daily: clear pending approvals grouped by priority.",
-      "Weekly: sync with procurement on escalations.",
-      "Quarterly: refresh delegation rules and playbooks.",
-    ],
-    tools: ["Approval brief", "Policy library", "Delegation planner"],
-  },
-  {
-    id: "requester",
-    label: "Requester",
-    headline: "Submit and follow with clarity",
-    summary:
-      "Requesters provide business cases, respond to clarifications, and track progress without leaving the workspace.",
-    responsibilities: [
-      "Complete guided intake with supporting documentation and stakeholders.",
-      "Respond promptly to questions from procurement or security.",
-      "Plan renewals early with the reminders and budget coordination tools.",
-    ],
-    cadence: [
-      "As needed: start intake before spend occurs.",
-      "During review: stay active in the request thread.",
-      "Post approval: confirm delivery and capture feedback.",
-    ],
-    tools: ["Guided request", "Tracking board", "Renewal planner"],
+    time: 'Friday',
+    title: 'Program review',
+    description:
+      'Metrics, automation health, and policy updates are published to leadership.',
   },
 ];
 
 const quickGuides = [
   {
-    title: "Workspace orientation",
-    description: "A 10-minute walkthrough that introduces intake, approvals, and the vendor desk.",
-    action: "Open guide",
+    title: 'Workspace orientation',
+    description:
+      'A 10-minute walkthrough that introduces intake, approvals, and the vendor desk.',
+    action: 'Open guide',
   },
   {
-    title: "Intake checklist",
-    description: "Share with requesters so every submission arrives complete the first time.",
-    action: "Download checklist",
+    title: 'Intake checklist',
+    description:
+      'Share with requesters so every submission arrives complete the first time.',
+    action: 'Download checklist',
   },
   {
-    title: "Renewal preparation",
-    description: "Template to plan vendor checkpoints, benchmarks, and stakeholder updates.",
-    action: "Review template",
+    title: 'Renewal preparation',
+    description:
+      'Template to plan vendor checkpoints, benchmarks, and stakeholder updates.',
+    action: 'Review template',
   },
 ];
 
 const accessSteps = [
   {
-    title: "Create your account",
+    title: 'Create your account',
     description:
-      "Use your company email to create a Procurement Manager account. Access is governed through SSO.",
-    meta: "Self-serve",
-    action: { label: "Create account", href: "/signup", tone: "primary" },
+      'Use your company email to create a Procurement Manager account. Access is governed through SSO.',
+    meta: 'Self-serve',
+    action: { label: 'Create account', href: '/signup', tone: 'primary' },
   },
   {
-    title: "Sign in securely",
+    title: 'Sign in securely',
     description:
-      "Sign in from any managed device using single sign-on. Multi-factor authentication is enforced by default.",
-    meta: "SSO",
-    action: { label: "Sign in", href: "/login", tone: "outline" },
+      'Sign in from any managed device using single sign-on. Multi-factor authentication is enforced by default.',
+    meta: 'SSO',
+    action: { label: 'Sign in', href: '/login', tone: 'outline' },
   },
   {
-    title: "Complete orientation",
+    title: 'Complete orientation',
     description:
-      "Before managing intake, review the quick orientation so you understand routing, approvals, and renewals.",
-    meta: "20 minutes",
-    action: { label: "Start orientation", href: "#resources", tone: "link" },
+      'Before managing intake, review the quick orientation so you understand routing, approvals, and renewals.',
+    meta: '20 minutes',
+    action: { label: 'Start orientation', href: '#resources', tone: 'link' },
   },
 ];
 
 export default function Landing() {
-  const [selectedRole, setSelectedRole] = useState(roleViews[0].id);
-  const activeRole = roleViews.find((role) => role.id === selectedRole) ?? roleViews[0];
+  const [heroMetrics, setHeroMetrics] = useState(() =>
+    HERO_METRIC_TEMPLATE.map((metric) => ({ ...metric }))
+  );
+  const [focusSignals, setFocusSignals] = useState(() =>
+    FOCUS_SIGNAL_TEMPLATE.map((signal) => ({ ...signal }))
+  );
+  const [roleViews, setRoleViews] = useState([]);
+  const [selectedRole, setSelectedRole] = useState(null);
+  const [landingDataError, setLandingDataError] = useState(false);
+
+  useEffect(() => {
+    let ignore = false;
+    async function loadLanding() {
+      try {
+        const data = await apiGet('/api/marketing/landing');
+        if (ignore) return;
+        const metrics =
+          Array.isArray(data.heroMetrics) && data.heroMetrics.length
+            ? data.heroMetrics
+            : HERO_METRIC_TEMPLATE;
+        const signals =
+          Array.isArray(data.focusSignals) && data.focusSignals.length
+            ? data.focusSignals
+            : FOCUS_SIGNAL_TEMPLATE;
+        const roles = Array.isArray(data.roleViews) ? data.roleViews : [];
+        setHeroMetrics(
+          metrics.map((metric) => ({
+            label: metric.label ?? '—',
+            value: metric.value ?? '—',
+          }))
+        );
+        setFocusSignals(
+          signals.map((signal) => ({
+            label: signal.label ?? '—',
+            value: signal.value ?? '—',
+            meta: signal.meta ?? '—',
+          }))
+        );
+        setRoleViews(
+          roles.map((role) => ({
+            ...role,
+            responsibilities: Array.isArray(role.responsibilities)
+              ? role.responsibilities
+              : [],
+            cadence: Array.isArray(role.cadence) ? role.cadence : [],
+            tools: Array.isArray(role.tools) ? role.tools : [],
+          }))
+        );
+        setLandingDataError(false);
+      } catch (error) {
+        if (ignore) return;
+        console.error('Failed to load landing data', error);
+        setHeroMetrics(HERO_METRIC_TEMPLATE.map((metric) => ({ ...metric })));
+        setFocusSignals(
+          FOCUS_SIGNAL_TEMPLATE.map((signal) => ({
+            ...signal,
+            value: '—',
+            meta: 'Live data unavailable',
+          }))
+        );
+        setRoleViews([]);
+        setLandingDataError(true);
+      }
+    }
+    loadLanding();
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!selectedRole && roleViews.length) {
+      setSelectedRole(roleViews[0].id);
+    }
+  }, [roleViews, selectedRole]);
+
+  const activeRole =
+    roleViews.find((role) => role.id === selectedRole) ??
+    (roleViews.length ? roleViews[0] : null);
 
   return (
     <div className="page">
@@ -269,8 +261,9 @@ export default function Landing() {
                   The control center for procurement operations
                 </h1>
                 <p className="hero-description">
-                  Procurement Manager is the internal workspace for intake, approvals, and vendor management. It is built for
-                  the teams already running the program—clarity first, marketing last.
+                  Procurement Manager is the internal workspace for intake,
+                  approvals, and vendor management. It is built for the teams
+                  already running the program—clarity first, marketing last.
                 </p>
                 <div className="hero-actions">
                   <a className="button primary" href="/login">
@@ -307,7 +300,9 @@ export default function Landing() {
                       </li>
                     ))}
                   </ul>
-                  <div className="brief-foot">Operations steady · Next review 15:00</div>
+                  <div className="brief-foot">
+                    Operations steady · Next review 15:00
+                  </div>
                 </div>
                 <div className="queue-card">
                   <div className="queue-header">
@@ -335,14 +330,18 @@ export default function Landing() {
           </div>
         </section>
 
-        <section className="program" id="program" aria-labelledby="program-heading">
+        <section
+          className="program"
+          id="program"
+          aria-labelledby="program-heading"
+        >
           <div className="shell">
             <div className="section-heading">
               <span className="kicker">Program foundations</span>
               <h2 id="program-heading">How the workspace runs</h2>
               <p>
-                Share this structure with new teammates. It keeps the program predictable and shows where each part of the
-                lifecycle lives.
+                Share this structure with new teammates. It keeps the program
+                predictable and shows where each part of the lifecycle lives.
               </p>
             </div>
             <div className="program-grid">
@@ -367,12 +366,17 @@ export default function Landing() {
               <span className="kicker">Operating rhythm</span>
               <h2 id="rituals-heading">Daily cadence that keeps us aligned</h2>
               <p>
-                A steady rhythm ensures intake stays healthy, approvals move, and renewals never surprise the business.
+                A steady rhythm ensures intake stays healthy, approvals move,
+                and renewals never surprise the business.
               </p>
             </div>
             <div className="timeline" role="list">
               {rituals.map((item) => (
-                <article className="timeline-row" role="listitem" key={item.title}>
+                <article
+                  className="timeline-row"
+                  role="listitem"
+                  key={item.title}
+                >
                   <div className="timeline-marker">
                     <span className="timeline-dot" />
                     <span className="timeline-time">{item.time}</span>
@@ -391,8 +395,13 @@ export default function Landing() {
           <div className="shell">
             <div className="section-heading">
               <span className="kicker">Role handbook</span>
-              <h2 id="roles-heading">Choose your view of Procurement Manager</h2>
-              <p>Select a role to see priorities, cadence, and the workspaces each team uses every day.</p>
+              <h2 id="roles-heading">
+                Choose your view of Procurement Manager
+              </h2>
+              <p>
+                Select a role to see priorities, cadence, and the workspaces
+                each team uses every day.
+              </p>
             </div>
             <div className="role-selector">
               <label className="role-label" htmlFor="role-select">
@@ -401,58 +410,81 @@ export default function Landing() {
               <select
                 id="role-select"
                 className="role-select"
-                value={selectedRole}
+                value={selectedRole ?? ''}
                 onChange={(event) => setSelectedRole(event.target.value)}
+                disabled={!roleViews.length}
               >
-                {roleViews.map((role) => (
-                  <option key={role.id} value={role.id}>
-                    {role.label}
-                  </option>
-                ))}
+                {roleViews.length === 0 ? (
+                  <option value="">Live data loading…</option>
+                ) : (
+                  roleViews.map((role) => (
+                    <option key={role.id} value={role.id}>
+                      {role.label}
+                    </option>
+                  ))
+                )}
               </select>
             </div>
             <article className="role-panel" aria-live="polite">
-              <div className="role-header">
-                <h3>{activeRole.headline}</h3>
-                <p>{activeRole.summary}</p>
-              </div>
-              <div className="role-columns">
-                <div className="role-column">
-                  <h4>Responsibilities</h4>
-                  <ul>
-                    {activeRole.responsibilities.map((item) => (
-                      <li key={item}>{item}</li>
-                    ))}
-                  </ul>
+              {activeRole ? (
+                <>
+                  <div className="role-header">
+                    <h3>{activeRole.headline}</h3>
+                    <p>{activeRole.summary}</p>
+                  </div>
+                  <div className="role-columns">
+                    <div className="role-column">
+                      <h4>Responsibilities</h4>
+                      <ul>
+                        {activeRole.responsibilities.map((item) => (
+                          <li key={item}>{item}</li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div className="role-column">
+                      <h4>Cadence</h4>
+                      <ul>
+                        {activeRole.cadence.map((item) => (
+                          <li key={item}>{item}</li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div className="role-column">
+                      <h4>Key surfaces</h4>
+                      <ul>
+                        {activeRole.tools.map((item) => (
+                          <li key={item}>{item}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <div className="role-header">
+                  <h3>Live role handbook unavailable</h3>
+                  <p>
+                    {landingDataError
+                      ? "We couldn't load role guidance from the workspace. Try refreshing."
+                      : 'Role guidance will appear once live data loads.'}
+                  </p>
                 </div>
-                <div className="role-column">
-                  <h4>Cadence</h4>
-                  <ul>
-                    {activeRole.cadence.map((item) => (
-                      <li key={item}>{item}</li>
-                    ))}
-                  </ul>
-                </div>
-                <div className="role-column">
-                  <h4>Key surfaces</h4>
-                  <ul>
-                    {activeRole.tools.map((item) => (
-                      <li key={item}>{item}</li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
+              )}
             </article>
           </div>
         </section>
 
-        <section className="guides" id="resources" aria-labelledby="guides-heading">
+        <section
+          className="guides"
+          id="resources"
+          aria-labelledby="guides-heading"
+        >
           <div className="shell">
             <div className="section-heading">
               <span className="kicker">Resources</span>
               <h2 id="guides-heading">Materials to keep everyone aligned</h2>
               <p>
-                These guides live in the workspace library. Share them in onboarding invites or quarterly enablement sessions.
+                These guides live in the workspace library. Share them in
+                onboarding invites or quarterly enablement sessions.
               </p>
             </div>
             <div className="guide-grid">
@@ -469,13 +501,18 @@ export default function Landing() {
           </div>
         </section>
 
-        <section className="access" id="access" aria-labelledby="access-heading">
+        <section
+          className="access"
+          id="access"
+          aria-labelledby="access-heading"
+        >
           <div className="shell">
             <div className="section-heading">
               <span className="kicker">Access & onboarding</span>
               <h2 id="access-heading">Get into Procurement Manager</h2>
               <p>
-                A short checklist for teammates joining the workspace. Share this page instead of a long orientation deck.
+                A short checklist for teammates joining the workspace. Share
+                this page instead of a long orientation deck.
               </p>
             </div>
             <div className="access-grid">
@@ -483,17 +520,19 @@ export default function Landing() {
                 <article className="access-card" key={step.title}>
                   <div className="access-card-header">
                     <h3>{step.title}</h3>
-                    {step.meta ? <span className="access-meta">{step.meta}</span> : null}
+                    {step.meta ? (
+                      <span className="access-meta">{step.meta}</span>
+                    ) : null}
                   </div>
                   <p>{step.description}</p>
                   {step.action ? (
-                    step.action.tone === "link" ? (
+                    step.action.tone === 'link' ? (
                       <a className="text-link" href={step.action.href}>
                         {step.action.label}
                       </a>
                     ) : (
                       <a
-                        className={`button ${step.action.tone === "outline" ? "outline" : "primary"}`}
+                        className={`button ${step.action.tone === 'outline' ? 'outline' : 'primary'}`}
                         href={step.action.href}
                       >
                         {step.action.label}


### PR DESCRIPTION
## Summary
- add a `/api/marketing/landing` endpoint that assembles hero metrics, focus signals, and role data from current procurement activity
- create a marketing role profiles migration so the marketing site pulls copy from stored CMS content
- update the landing page to fetch live marketing data with loading fallbacks and error messaging

## Testing
- npm run lint
- npx prettier --check backend/server.js frontend/src/pages/Landing.jsx backend/migrations/013_marketing_role_profiles.sql

------
https://chatgpt.com/codex/tasks/task_e_68ccc951ebbc832a8aefebdbd21a7dcd