### PR TITLE
Add intake readiness checklist resource

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -816,3 +816,346 @@ h2 {
     padding: 0 1.1rem;
   }
 }
+
+/* Intake checklist page */
+.checklist-page {
+  background: var(--bg);
+  background-image: var(--bg-gradient);
+  color: var(--text);
+}
+
+.checklist-hero {
+  padding: 140px 0 100px;
+  background: linear-gradient(
+    135deg,
+    rgba(37, 99, 235, 0.12),
+    rgba(14, 165, 233, 0.04)
+  );
+  border-bottom: 1px solid var(--surface-border);
+}
+
+.checklist-hero-content {
+  max-width: 720px;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.checklist-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--accent-strong);
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.checklist-hero h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 5vw, 3.4rem);
+  color: var(--text-strong);
+  line-height: 1.1;
+}
+
+.checklist-hero p {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--text-muted);
+}
+
+.checklist-progress-card {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--surface-border);
+  padding: 1.6rem;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.9rem;
+  max-width: 360px;
+}
+
+.checklist-progress-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.checklist-progress-track {
+  position: relative;
+  width: 100%;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--surface-muted);
+  overflow: hidden;
+}
+
+.checklist-progress-fill {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  transition: width 0.25s ease;
+}
+
+.checklist-reset {
+  appearance: none;
+  border: none;
+  background: none;
+  color: var(--accent);
+  font-weight: 500;
+  font-size: 0.85rem;
+  cursor: pointer;
+  justify-self: flex-end;
+  padding: 0;
+}
+
+.checklist-reset:hover,
+.checklist-reset:focus {
+  color: var(--accent-strong);
+}
+
+.checklist-content {
+  padding: 96px 0 140px;
+}
+
+.checklist-shell {
+  display: grid;
+  gap: 3rem;
+}
+
+.checklist-heading {
+  margin: 0;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--text-soft);
+  font-weight: 600;
+}
+
+.checklist-sections {
+  display: grid;
+  gap: 2.5rem;
+}
+
+.checklist-section {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-soft);
+  padding: 2.4rem;
+  display: grid;
+  gap: 1.6rem;
+}
+
+.checklist-section-head {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.checklist-section-head h3 {
+  margin: 0;
+  color: var(--text-strong);
+  font-size: 1.35rem;
+}
+
+.checklist-section-head p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.checklist-section-progress {
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-soft);
+}
+
+.checklist-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.checklist-item {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.78);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.checklist-item:hover,
+.checklist-item:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 18px 32px rgba(37, 99, 235, 0.16);
+  transform: translateY(-2px);
+}
+
+.checklist-item.is-complete {
+  border-color: rgba(22, 163, 74, 0.4);
+  background: rgba(240, 253, 244, 0.85);
+  box-shadow: 0 18px 34px rgba(22, 163, 74, 0.16);
+}
+
+.checklist-item-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  cursor: pointer;
+}
+
+.checklist-checkbox {
+  width: 22px;
+  height: 22px;
+  margin-top: 0.2rem;
+  flex-shrink: 0;
+  accent-color: var(--accent);
+  border-radius: 6px;
+}
+
+.checklist-item.is-complete .checklist-checkbox {
+  accent-color: var(--positive);
+}
+
+.checklist-item-content {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.checklist-item-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.checklist-item-title {
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.checklist-item-detail {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.93rem;
+}
+
+.checklist-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: var(--surface-muted);
+  color: var(--text-muted);
+}
+
+.checklist-badge.is-recommended {
+  background: rgba(37, 99, 235, 0.16);
+  color: var(--accent-strong);
+}
+
+.checklist-badge.is-optional {
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--text-soft);
+}
+
+.checklist-aside {
+  display: grid;
+  gap: 2rem;
+}
+
+.checklist-callout {
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--surface-border);
+  box-shadow: var(--shadow-soft);
+  padding: 2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.checklist-callout h3 {
+  margin: 0;
+  color: var(--text-strong);
+}
+
+.checklist-callout p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.checklist-callout ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--text-muted);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.checklist-callout li {
+  line-height: 1.5;
+}
+
+@media (min-width: 1100px) {
+  .checklist-shell {
+    grid-template-columns: minmax(0, 3fr) minmax(0, 1.35fr);
+    align-items: start;
+  }
+}
+
+@media (max-width: 960px) {
+  .checklist-progress-card {
+    max-width: none;
+  }
+}
+
+@media (max-width: 900px) {
+  .checklist-aside {
+    order: -1;
+  }
+}
+
+@media (max-width: 720px) {
+  .checklist-section {
+    padding: 1.9rem;
+  }
+
+  .checklist-item-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.45rem;
+  }
+}
+
+@media (max-width: 560px) {
+  .checklist-section {
+    padding: 1.6rem;
+  }
+
+  .checklist-item-label {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.8rem;
+  }
+
+  .checklist-checkbox {
+    margin-top: 0;
+  }
+
+  .checklist-progress-card {
+    padding: 1.4rem;
+  }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import "./index.css";
 import Landing from "./pages/Landing";
+import IntakeChecklist from "./pages/IntakeChecklist";
 import App from "./App";
 import Dashboard from "./pages/Dashboard";
 import Requests from "./pages/Requests";
@@ -20,6 +21,10 @@ ReactDOM.createRoot(document.getElementById("root")).render(
       <AuthProvider>
         <Routes>
           <Route path="/" element={<Landing />} />
+          <Route
+            path="/resources/intake-checklist"
+            element={<IntakeChecklist />}
+          />
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
           <Route

--- a/frontend/src/pages/IntakeChecklist.jsx
+++ b/frontend/src/pages/IntakeChecklist.jsx
@@ -1,0 +1,355 @@
+import { useState } from 'react';
+
+const navLinks = [
+  { label: 'Overview', href: '/#overview' },
+  { label: 'Program', href: '/#program' },
+  { label: 'Roles', href: '/#roles' },
+  { label: 'Resources', href: '/#resources' },
+  { label: 'Access', href: '/#access' },
+];
+
+const checklistSections = [
+  {
+    id: 'context',
+    title: 'Clarify the request',
+    description:
+      'Give reviewers the story, urgency, and stakeholders behind the purchase.',
+    items: [
+      {
+        id: 'problem',
+        label: 'Problem statement or objective this request addresses',
+      },
+      {
+        id: 'sponsor',
+        label: 'Business sponsor and directly responsible individual',
+        detail:
+          'Include name, title, and contact so Procurement can loop them in quickly.',
+      },
+      {
+        id: 'impact',
+        label: 'Teams or processes impacted by the decision',
+        detail: 'Call out integrations or dependencies that need coordination.',
+        importance: 'recommended',
+      },
+      {
+        id: 'timeline',
+        label: 'Target go-live or deadline and any immovable dates',
+      },
+      {
+        id: 'outcomes',
+        label: 'How success will be measured once the solution is live',
+        importance: 'recommended',
+      },
+    ],
+  },
+  {
+    id: 'financials',
+    title: 'Lock in budget details',
+    description: 'Confirm where the spend lands and who approves it.',
+    items: [
+      {
+        id: 'spend',
+        label: 'Estimated total contract value (first year and full term)',
+      },
+      {
+        id: 'budget-owner',
+        label: 'Budget owner or cost center with confirmation funds exist',
+      },
+      {
+        id: 'category',
+        label: 'Procurement category, GL code, or project code to charge',
+      },
+      {
+        id: 'approvers',
+        label: 'Delegation of authority path and known approvers',
+      },
+      {
+        id: 'renewal',
+        label: 'Contract term length and renewal or cancellation notice period',
+        importance: 'recommended',
+      },
+    ],
+  },
+  {
+    id: 'vendor',
+    title: 'Prepare vendor diligence',
+    description:
+      'Surface the risk posture so security, legal, and compliance can act quickly.',
+    items: [
+      {
+        id: 'vendor',
+        label: 'Preferred supplier or shortlisted vendors with contacts',
+      },
+      {
+        id: 'alternatives',
+        label: 'Alternatives reviewed or justification for a sole-source choice',
+        importance: 'recommended',
+      },
+      {
+        id: 'data',
+        label: 'Data classification and systems the vendor will access or integrate',
+      },
+      {
+        id: 'requirements',
+        label: 'Security, privacy, or compliance requirements that must be met',
+      },
+      {
+        id: 'documentation',
+        label: 'Latest security questionnaire, SOC/ISO reports, or DPAs on file',
+        importance: 'optional',
+        detail: 'Upload directly to the request when they are available.',
+      },
+    ],
+  },
+  {
+    id: 'execution',
+    title: 'Plan delivery and handoff',
+    description:
+      'Make sure owners, timing, and transition plans are in place before approvals begin.',
+    items: [
+      {
+        id: 'owner',
+        label: 'Implementation lead and ongoing vendor relationship owner',
+      },
+      {
+        id: 'partners',
+        label: 'IT, security, legal, and finance partners notified of the request',
+      },
+      {
+        id: 'training',
+        label: 'Enablement or rollout plan for impacted teams',
+        importance: 'recommended',
+      },
+      {
+        id: 'support',
+        label: 'Support model or vendor SLAs after go-live',
+      },
+      {
+        id: 'metrics',
+        label: 'Plan for monitoring adoption, spend, and outcomes post-launch',
+        importance: 'optional',
+      },
+    ],
+  },
+];
+
+const readinessHighlights = [
+  'Reviewers receive complete budget and risk context on the first pass.',
+  'Approvers can focus on decisions instead of chasing missing details.',
+  'Renewal and vendor owners are identified before contracts are signed.',
+];
+
+const totalChecklistItems = checklistSections.reduce(
+  (count, section) => count + section.items.length,
+  0
+);
+
+export default function IntakeChecklist() {
+  const [completedItems, setCompletedItems] = useState(() => new Set());
+
+  const percentComplete = totalChecklistItems
+    ? Math.round((completedItems.size / totalChecklistItems) * 100)
+    : 0;
+  const progressLabel = `${completedItems.size} of ${totalChecklistItems} items ready`;
+
+  function toggleItem(id) {
+    setCompletedItems((previous) => {
+      const next = new Set(previous);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  function resetChecklist() {
+    setCompletedItems(new Set());
+  }
+
+  return (
+    <div className="page checklist-page">
+      <header className="site-header" id="top">
+        <div className="shell nav-shell">
+          <a className="brand" href="/">
+            <span className="brand-mark" aria-hidden="true" />
+            <span>Procurement Manager</span>
+          </a>
+          <nav className="nav-links" aria-label="Primary">
+            {navLinks.map((link) => (
+              <a key={link.href} href={link.href}>
+                {link.label}
+              </a>
+            ))}
+          </nav>
+          <div className="nav-actions">
+            <a className="nav-link" href="/login">
+              Sign in
+            </a>
+            <a className="nav-cta" href="/signup">
+              Create account
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <main>
+        <section
+          className="checklist-hero"
+          aria-labelledby="intake-checklist-title"
+        >
+          <div className="shell">
+            <div className="checklist-hero-content">
+              <span className="checklist-eyebrow">Intake enablement</span>
+              <h1 id="intake-checklist-title">Intake readiness checklist</h1>
+              <p>
+                Make sure every request enters Procurement Manager with the
+                budget, risk, and delivery details partners expect. Share this
+                checklist with requesters before they submit.
+              </p>
+              <div className="checklist-progress-card">
+                <div className="checklist-progress-meta" aria-live="polite">
+                  <span>{progressLabel}</span>
+                  <span>{percentComplete}%</span>
+                </div>
+                <div
+                  className="checklist-progress-track"
+                  role="progressbar"
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-valuenow={percentComplete}
+                  aria-valuetext={progressLabel}
+                >
+                  <div
+                    className="checklist-progress-fill"
+                    style={{ width: `${percentComplete}%` }}
+                  />
+                </div>
+                {completedItems.size ? (
+                  <button
+                    type="button"
+                    className="checklist-reset"
+                    onClick={resetChecklist}
+                  >
+                    Reset checklist
+                  </button>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section
+          className="checklist-content"
+          aria-labelledby="checklist-sections-heading"
+        >
+          <div className="shell checklist-shell">
+            <div className="checklist-sections">
+              <h2 id="checklist-sections-heading" className="checklist-heading">
+                What to capture before intake
+              </h2>
+              {checklistSections.map((section) => {
+                const sectionCompleted = section.items.reduce(
+                  (count, item, index) =>
+                    completedItems.has(`${section.id}-${item.id ?? index}`)
+                      ? count + 1
+                      : count,
+                  0
+                );
+
+                return (
+                  <section
+                    key={section.id}
+                    className="checklist-section"
+                    aria-labelledby={`section-${section.id}`}
+                  >
+                    <div className="checklist-section-head">
+                      <h3 id={`section-${section.id}`}>{section.title}</h3>
+                      <p>{section.description}</p>
+                      <span className="checklist-section-progress">
+                        {sectionCompleted} of {section.items.length} ready
+                      </span>
+                    </div>
+                    <ul className="checklist-items">
+                      {section.items.map((item, index) => {
+                        const itemId = `${section.id}-${item.id ?? index}`;
+                        const isChecked = completedItems.has(itemId);
+                        const importance = item.importance ?? 'required';
+                        const badgeLabel =
+                          importance === 'recommended'
+                            ? 'Recommended'
+                            : importance === 'optional'
+                            ? 'Optional'
+                            : null;
+
+                        return (
+                          <li
+                            key={itemId}
+                            className={`checklist-item${
+                              isChecked ? ' is-complete' : ''
+                            }`}
+                          >
+                            <label className="checklist-item-label">
+                              <input
+                                type="checkbox"
+                                className="checklist-checkbox"
+                                checked={isChecked}
+                                onChange={() => toggleItem(itemId)}
+                              />
+                              <div className="checklist-item-content">
+                                <div className="checklist-item-row">
+                                  <span className="checklist-item-title">
+                                    {item.label}
+                                  </span>
+                                  {badgeLabel ? (
+                                    <span
+                                      className={`checklist-badge ${
+                                        importance === 'recommended'
+                                          ? 'is-recommended'
+                                          : 'is-optional'
+                                      }`}
+                                    >
+                                      {badgeLabel}
+                                    </span>
+                                  ) : null}
+                                </div>
+                                {item.detail ? (
+                                  <p className="checklist-item-detail">
+                                    {item.detail}
+                                  </p>
+                                ) : null}
+                              </div>
+                            </label>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </section>
+                );
+              })}
+            </div>
+            <aside className="checklist-aside" aria-label="Enablement guidance">
+              <div className="checklist-callout">
+                <h3>How to use this checklist</h3>
+                <p>
+                  Drop the link into intake forms, onboarding docs, or Slack
+                  reminders. Aligning on expectations up front keeps requests
+                  moving without Procurement chasing fundamentals.
+                </p>
+              </div>
+              <div className="checklist-callout">
+                <h3>What complete looks like</h3>
+                <ul>
+                  {readinessHighlights.map((highlight) => (
+                    <li key={highlight}>{highlight}</li>
+                  ))}
+                </ul>
+              </div>
+            </aside>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/Landing.jsx
+++ b/frontend/src/pages/Landing.jsx
@@ -109,8 +109,9 @@ const quickGuides = [
   {
     title: 'Intake checklist',
     description:
-      'Share with requesters so every submission arrives complete the first time.',
-    action: 'Download checklist',
+      'Interactive readiness checklist covering budget, risk, and rollout details to collect before intake.',
+    action: 'Open checklist',
+    href: '/resources/intake-checklist',
   },
   {
     title: 'Renewal preparation',
@@ -141,6 +142,17 @@ const accessSteps = [
       'Before managing intake, review the quick orientation so you understand routing, approvals, and renewals.',
     meta: '20 minutes',
     action: { label: 'Start orientation', href: '#resources', tone: 'link' },
+  },
+  {
+    title: 'Review intake checklist',
+    description:
+      'Align requesters on the budget, risk, and rollout details Procurement expects before they submit.',
+    meta: 'Shared resource',
+    action: {
+      label: 'Open checklist',
+      href: '/resources/intake-checklist',
+      tone: 'link',
+    },
   },
 ];
 
@@ -492,9 +504,15 @@ export default function Landing() {
                 <article className="guide-card" key={guide.title}>
                   <h3>{guide.title}</h3>
                   <p>{guide.description}</p>
-                  <button type="button" className="text-button">
-                    {guide.action}
-                  </button>
+                  {guide.href ? (
+                    <a className="text-button" href={guide.href}>
+                      {guide.action}
+                    </a>
+                  ) : (
+                    <button type="button" className="text-button">
+                      {guide.action}
+                    </button>
+                  )}
                 </article>
               ))}
             </div>
@@ -512,7 +530,9 @@ export default function Landing() {
               <h2 id="access-heading">Get into Procurement Manager</h2>
               <p>
                 A short checklist for teammates joining the workspace. Share
-                this page instead of a long orientation deck.
+                this page instead of a long orientation deck, and use the
+                intake readiness checklist to set expectations for
+                requesters.
               </p>
             </div>
             <div className="access-grid">


### PR DESCRIPTION
## Summary
- add a dedicated intake readiness checklist page with interactive progress tracking and enablement callouts
- link the new checklist from the public router, quick guides, and onboarding access steps on the landing page
- style the checklist experience with bespoke layout, item, and responsive rules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd5cd52584832a9c6bbae559c26760