### PR TITLE
Implement reusable auth service for login and signup

### DIFF
--- a/frontend/src/lib/auth.jsx
+++ b/frontend/src/lib/auth.jsx
@@ -1,6 +1,14 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Navigate, useLocation } from "react-router-dom";
-import { apiGet } from "./api";
+import { apiGet, apiPost } from "./api";
 
 const AuthContext = createContext(null);
 
@@ -56,9 +64,34 @@ export function AuthProvider({ children }) {
     setSession(null, null);
   }, [setSession]);
 
+  const login = useCallback(
+    async (email, password) => {
+      const { token, user: nextUser } = await apiPost("/api/auth/login", {
+        email,
+        password,
+      });
+      setSession(token, nextUser);
+      return nextUser;
+    },
+    [setSession]
+  );
+
+  const signup = useCallback(
+    async (email, password, role = "requester") => {
+      const { token, user: nextUser } = await apiPost("/api/auth/signup", {
+        email,
+        password,
+        role,
+      });
+      setSession(token, nextUser);
+      return nextUser;
+    },
+    [setSession]
+  );
+
   const value = useMemo(
-    () => ({ user, status, setSession, logout, bootstrap }),
-    [user, status, setSession, logout, bootstrap]
+    () => ({ user, status, setSession, logout, bootstrap, login, signup }),
+    [user, status, setSession, logout, bootstrap, login, signup]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import AuthLayout from "../components/AuthLayout";
-import { apiPost } from "../lib/api";
 import { useAuth } from "../lib/auth";
 
 const inputClass =
@@ -37,7 +36,7 @@ export default function Login() {
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
-  const { setSession } = useAuth();
+  const { login: authenticate } = useAuth();
   const redirectTo = location.state?.from || "/app";
 
   async function submit(e) {
@@ -45,8 +44,7 @@ export default function Login() {
     setErr("");
     setLoading(true);
     try {
-      const { token, user } = await apiPost("/api/auth/login", { email, password });
-      setSession(token, user);
+      await authenticate(email, password);
       navigate(redirectTo, { replace: true });
     } catch {
       setErr("Invalid email or password. Please try again.");

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import AuthLayout from "../components/AuthLayout";
-import { apiPost } from "../lib/api";
 import { useAuth } from "../lib/auth";
 
 const inputClass =
@@ -59,7 +58,7 @@ export default function Signup() {
   const [err, setErr] = useState("");
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
-  const { setSession } = useAuth();
+  const { signup: register } = useAuth();
 
   async function submit(e) {
     e.preventDefault();
@@ -74,8 +73,7 @@ export default function Signup() {
     }
     setLoading(true);
     try {
-      const res = await apiPost("/api/auth/signup", { email, password, role: "admin" });
-      setSession(res.token, res.user);
+      await register(email, password, "admin");
       navigate("/app", { replace: true });
     } catch (e) {
       const msg = String(e.message || "").includes("409")


### PR DESCRIPTION
## Summary
- add login and signup helpers to the auth provider so tokens are persisted consistently
- update the login and signup pages to call the shared auth helpers

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd6066a654832a900ec831e85b29da