### PR TITLE
Guard approvals by role

### DIFF
--- a/frontend/src/pages/RequestDetail.jsx
+++ b/frontend/src/pages/RequestDetail.jsx
@@ -1,13 +1,17 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 import Drawer from "../components/Drawer";
 import { Tabs } from "../components/Tabs";
 import Badge from "../components/Badge";
 import Button from "../components/Button";
 import { apiGet, apiUpload, apiPost } from "../lib/api";
+import { useAuth } from "../lib/auth";
+import { useToast } from "../components/toast";
 
 export default function RequestDetailDrawer({ open, onClose }) {
   const { id } = useParams();
+  const { user } = useAuth();
+  const toast = useToast();
   const [req, setReq] = useState(null);
   const [files, setFiles] = useState([]);
   const [tab, setTab] = useState("Overview");
@@ -16,18 +20,28 @@ export default function RequestDetailDrawer({ open, onClose }) {
   const [comments, setComments] = useState([]);
   const [newComment, setNewComment] = useState("");
   const [loading, setLoading] = useState(true);
+  const [stages, setStages] = useState();
+  const [acting, setActing] = useState(null);
+
+  const userRole = user?.role || "";
 
   async function load() {
     setLoading(true);
+    setStages(undefined);
     try{
-      const [list, st, cm, au] = await Promise.all([
+      const [list, st, cm, au, ap] = await Promise.all([
         apiGet("/api/requests"),
         apiGet(`/api/requests/${id}/files`).catch(()=>[]),
         apiGet(`/api/requests/${id}/comments`).catch(()=>[]),
-        apiGet(`/api/requests/${id}/audit`).catch(()=>[])
+        apiGet(`/api/requests/${id}/audit`).catch(()=>[]),
+        apiGet(`/api/requests/${id}/approvals`).catch((err) => {
+          console.error(`Failed to load approvals for request ${id}`, err);
+          return null;
+        })
       ]);
       setReq(list.find(r=> String(r.id)===String(id)) || null);
       setFiles(st||[]); setComments(cm||[]); setAudit(au||[]);
+      setStages(ap);
     } finally { setLoading(false); }
   }
   useEffect(()=>{ if(open) load(); }, [id, open]);
@@ -47,9 +61,47 @@ export default function RequestDetailDrawer({ open, onClose }) {
   }
 
   async function approve(){
-    await apiPost(`/api/requests/${id}/approve`, {});
-    setAudit(await apiGet(`/api/requests/${id}/audit`));
+    setActing("approve");
+    try {
+      await apiPost(`/api/requests/${id}/approve`, {});
+      toast?.success("Approval recorded");
+      await load();
+    } catch (err) {
+      console.error(err);
+      toast?.error(friendlyApiError(err, "Approve failed"));
+    } finally {
+      setActing(null);
+    }
   }
+
+  async function deny(){
+    setActing("deny");
+    try {
+      await apiPost(`/api/requests/${id}/deny`, {});
+      toast?.info("Denial recorded");
+      await load();
+    } catch (err) {
+      console.error(err);
+      toast?.error(friendlyApiError(err, "Deny failed"));
+    } finally {
+      setActing(null);
+    }
+  }
+
+  const pendingStage = useMemo(() => {
+    if (!Array.isArray(stages)) return null;
+    return stages.find((stage) => stage.status === "pending") || null;
+  }, [stages]);
+  const totalStages = Array.isArray(stages) ? stages.length : 0;
+  const canAct = canActOnStage({ request: req, pendingStage, userRole });
+  const stageMessage = renderDetailStageMessage({
+    request: req,
+    stages,
+    pendingStage,
+    userRole,
+    totalStages,
+  });
+  const isActing = acting !== null;
 
   return (
     <Drawer open={open} title={req ? `Request #${req.id}` : "Request"} onClose={onClose}
@@ -69,8 +121,20 @@ export default function RequestDetailDrawer({ open, onClose }) {
               <Row k="Vendor" v={req.vendor_name || "—"} />
               <Row k="PO Number" v={req.po_number || "—"} />
               <Row k="Created" v={new Date(req.created_at).toLocaleString()} />
-              <div className="flex gap-2">
-                <Button variant="ghost" onClick={approve}>Approve</Button>
+              <div className="space-y-1">
+                <div className="flex gap-2">
+                  <Button
+                    variant="ghost"
+                    onClick={approve}
+                    disabled={!canAct || isActing}
+                  >Approve</Button>
+                  <Button
+                    variant="ghost"
+                    onClick={deny}
+                    disabled={!canAct || isActing}
+                  >Deny</Button>
+                </div>
+                {stageMessage}
               </div>
             </div>
           )}
@@ -127,6 +191,106 @@ export default function RequestDetailDrawer({ open, onClose }) {
     </Drawer>
   );
 }
+
+function canActOnStage({ request, pendingStage, userRole }) {
+  if (!request || request.status !== "pending") return false;
+  if (!userRole) return false;
+  if (userRole === "admin") return true;
+  if (!pendingStage || !pendingStage.role_required) return false;
+  return pendingStage.role_required === userRole;
+}
+
+function renderDetailStageMessage({ request, stages, pendingStage, userRole, totalStages }) {
+  if (!request) return null;
+  const base = "text-xs text-slate-500";
+
+  if (request.status !== "pending") {
+    if (request.status === "approved")
+      return <div className={base}>All approval stages completed.</div>;
+    if (request.status === "denied")
+      return <div className={base}>Request has been denied.</div>;
+    return <div className={base}>No approval actions available.</div>;
+  }
+
+  if (stages === null) return <div className={base}>Approval routing unavailable.</div>;
+  if (typeof stages === "undefined")
+    return <div className={base}>Loading approval routing…</div>;
+
+  if (!pendingStage) {
+    if (Array.isArray(stages) && stages.every((stage) => stage.status === "approved"))
+      return <div className={base}>All stages are complete.</div>;
+    return <div className={base}>No pending stage.</div>;
+  }
+
+  const rawIndex = Number(pendingStage.stage_index);
+  const stageNumber = Number.isFinite(rawIndex) ? rawIndex + 1 : null;
+  const stagePrefix =
+    stageNumber !== null
+      ? totalStages > 0
+        ? `Stage ${stageNumber} of ${totalStages}`
+        : `Stage ${stageNumber}`
+      : "Current stage";
+  const roleLabel = formatRole(pendingStage.role_required);
+
+  if (!userRole)
+    return <div className={base}>{`${stagePrefix}: checking permissions…`}</div>;
+
+  if (userRole === "admin") {
+    const suffix = roleLabel ? `for ${roleLabel}.` : "for this stage.";
+    return <div className={base}>{`${stagePrefix}: admin override available ${suffix}`}</div>;
+  }
+
+  if (pendingStage.role_required && pendingStage.role_required !== userRole) {
+    return (
+      <div className={base}>{`${stagePrefix}: waiting on ${roleLabel || "another role"}.`}</div>
+    );
+  }
+
+  if (roleLabel)
+    return <div className={base}>{`${stagePrefix}: you're assigned as ${roleLabel}.`}</div>;
+
+  return <div className={base}>{`${stagePrefix}: you can act on this stage.`}</div>;
+}
+
+function formatRole(role) {
+  if (!role) return "";
+  return role
+    .toString()
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function parseApiError(err) {
+  const message = typeof err === "string" ? err : err?.message || "";
+  if (!message) return null;
+  const parts = message.split("::");
+  if (parts.length > 1) {
+    const jsonPart = parts[parts.length - 1].trim();
+    try {
+      const parsed = JSON.parse(jsonPart);
+      if (parsed && typeof parsed.error === "string") return parsed.error;
+    } catch (_) {
+      /* ignore parse errors */
+    }
+  }
+  if (message.includes(" 403 ")) return "Not authorized for this stage";
+  if (message.includes(" 400 ")) return "No pending stage";
+  if (message.toLowerCase().includes("failed to fetch")) return "Network error";
+  return null;
+}
+
+function friendlyApiError(err, fallback = "Action failed") {
+  const raw = parseApiError(err);
+  if (raw === "wrong role for this stage" || raw === "Not authorized for this stage")
+    return "This request is waiting on another role.";
+  if (raw === "No pending stage" || raw === "no pending stage")
+    return "No pending stage to act on.";
+  if (raw) return raw;
+  return fallback;
+}
+
 function Row({ k, v }){ return (
   <div className="flex items-center justify-between">
     <div className="text-sm text-slate-500">{k}</div>


### PR DESCRIPTION
## Summary
- load approval stage data for each request row and gate approve/deny buttons based on the signed-in user’s role
- surface stage context and both approve and deny actions inside the request detail drawer so users know who is up next
- add helper logic to format stage roles and translate API errors into friendly messages for approvers

## Testing
- npm run format *(fails: existing Prettier violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd66d135fc832a84bfadce37df9846