### PR TITLE
Add database-backed purchase order management

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -1,9 +1,13 @@
 const { Pool } = require('pg');
 
+const connectionString =
+  process.env.DATABASE_URL ||
+  'postgres://postgres:postgres@localhost:5432/procurement_db';
+const needsSSL = /render\.com|sslmode=require/i.test(connectionString);
+
 const pool = new Pool({
-  connectionString:
-    process.env.DATABASE_URL ||
-    'postgres://postgres:postgres@localhost:5432/procurement_db',
+  connectionString,
+  ssl: needsSSL ? { rejectUnauthorized: false } : false,
 });
 
 module.exports = {

--- a/backend/migrations/014_purchase_orders_extend.sql
+++ b/backend/migrations/014_purchase_orders_extend.sql
@@ -1,0 +1,44 @@
+ALTER TABLE purchase_orders
+  ADD COLUMN IF NOT EXISTS po_number TEXT,
+  ADD COLUMN IF NOT EXISTS status TEXT,
+  ADD COLUMN IF NOT EXISTS vendor_id INTEGER REFERENCES vendors(id),
+  ADD COLUMN IF NOT EXISTS notes TEXT,
+  ADD COLUMN IF NOT EXISTS expected_date DATE,
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW();
+
+UPDATE purchase_orders
+  SET status = COALESCE(status, 'draft'),
+      updated_at = COALESCE(updated_at, created_at, NOW());
+
+UPDATE purchase_orders
+  SET created_at = NOW()
+  WHERE created_at IS NULL;
+
+ALTER TABLE purchase_orders
+  ALTER COLUMN status SET DEFAULT 'draft',
+  ALTER COLUMN status SET NOT NULL,
+  ALTER COLUMN updated_at SET DEFAULT NOW(),
+  ALTER COLUMN updated_at SET NOT NULL,
+  ALTER COLUMN created_at SET DEFAULT NOW(),
+  ALTER COLUMN created_at SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'purchase_orders_status_check'
+      AND conrelid = 'purchase_orders'::regclass
+  ) THEN
+    ALTER TABLE purchase_orders
+      ADD CONSTRAINT purchase_orders_status_check
+      CHECK (status IN ('draft','issued','receiving','received','cancelled'));
+  END IF;
+END$$;
+
+CREATE INDEX IF NOT EXISTS idx_purchase_orders_vendor_id ON purchase_orders(vendor_id);
+CREATE INDEX IF NOT EXISTS idx_purchase_orders_request_id ON purchase_orders(request_id);
+CREATE INDEX IF NOT EXISTS idx_purchase_orders_status ON purchase_orders(status);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_purchase_orders_po_number_unique
+  ON purchase_orders(po_number)
+  WHERE po_number IS NOT NULL;

--- a/backend/models/order.js
+++ b/backend/models/order.js
@@ -1,35 +1,134 @@
-let orders = [];
-let nextId = 1;
+const { pool } = require('../db');
+
+const ORDER_STATUSES = ['draft', 'issued', 'receiving', 'received', 'cancelled'];
+const ORDER_SELECT = `
+  o.id,
+  o.po_number,
+  o.status,
+  o.total,
+  o.vendor,
+  o.vendor_id,
+  o.request_id,
+  o.expected_date,
+  o.notes,
+  o.created_at,
+  o.updated_at,
+  v.name AS vendor_name,
+  r.title AS request_title
+`;
 
 async function getAll() {
-  return orders;
+  const { rows } = await pool.query(
+    `SELECT ${ORDER_SELECT}
+       FROM purchase_orders o
+       LEFT JOIN vendors v ON v.id = o.vendor_id
+       LEFT JOIN requests r ON r.id = o.request_id
+     ORDER BY o.created_at DESC`
+  );
+  return rows;
 }
 
 async function findById(id) {
-  return orders.find((o) => o.id === Number(id));
+  const { rows } = await pool.query(
+    `SELECT ${ORDER_SELECT}
+       FROM purchase_orders o
+       LEFT JOIN vendors v ON v.id = o.vendor_id
+       LEFT JOIN requests r ON r.id = o.request_id
+      WHERE o.id = $1`,
+    [id]
+  );
+  return rows[0] || null;
 }
 
-async function create(data) {
-  const order = { id: nextId++, ...data };
-  orders.push(order);
-  return order;
+async function create({
+  po_number = null,
+  vendor_name,
+  vendor_id = null,
+  total,
+  status,
+  request_id = null,
+  expected_date = null,
+  notes = null,
+}) {
+  const { rows } = await pool.query(
+    `INSERT INTO purchase_orders (po_number, vendor, vendor_id, total, status, request_id, expected_date, notes)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     RETURNING id`,
+    [po_number || null, vendor_name, vendor_id, total, status, request_id, expected_date, notes]
+  );
+  return rows[0] ? findById(rows[0].id) : null;
 }
 
-async function update(id, data) {
-  const index = orders.findIndex((o) => o.id === Number(id));
-  if (index === -1) return null;
-  orders[index] = { ...orders[index], ...data };
-  return orders[index];
+async function update(id, updates = {}) {
+  const fields = [];
+  const values = [];
+  let index = 1;
+
+  if (Object.prototype.hasOwnProperty.call(updates, 'po_number')) {
+    fields.push(`po_number = $${index}`);
+    values.push(updates.po_number || null);
+    index += 1;
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, 'vendor_name')) {
+    fields.push(`vendor = $${index}`);
+    values.push(updates.vendor_name);
+    index += 1;
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, 'vendor_id')) {
+    fields.push(`vendor_id = $${index}`);
+    values.push(updates.vendor_id);
+    index += 1;
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, 'total')) {
+    fields.push(`total = $${index}`);
+    values.push(updates.total);
+    index += 1;
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, 'status')) {
+    fields.push(`status = $${index}`);
+    values.push(updates.status);
+    index += 1;
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, 'request_id')) {
+    fields.push(`request_id = $${index}`);
+    values.push(updates.request_id);
+    index += 1;
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, 'expected_date')) {
+    fields.push(`expected_date = $${index}`);
+    values.push(updates.expected_date);
+    index += 1;
+  }
+  if (Object.prototype.hasOwnProperty.call(updates, 'notes')) {
+    fields.push(`notes = $${index}`);
+    values.push(updates.notes);
+    index += 1;
+  }
+
+  if (!fields.length) {
+    return findById(id);
+  }
+
+  fields.push('updated_at = NOW()');
+
+  const { rowCount } = await pool.query(
+    `UPDATE purchase_orders
+        SET ${fields.join(', ')}
+      WHERE id = $${index}`,
+    [...values, id]
+  );
+
+  if (!rowCount) return null;
+  return findById(id);
 }
 
 async function remove(id) {
-  const index = orders.findIndex((o) => o.id === Number(id));
-  if (index === -1) return false;
-  orders.splice(index, 1);
-  return true;
+  const { rowCount } = await pool.query('DELETE FROM purchase_orders WHERE id = $1', [id]);
+  return rowCount > 0;
 }
 
 module.exports = {
+  ORDER_STATUSES,
   getAll,
   findById,
   create,

--- a/backend/routes/orders.js
+++ b/backend/routes/orders.js
@@ -1,58 +1,221 @@
 const express = require('express');
 const Orders = require('../models/order');
+const { query } = require('../db');
 
 const router = express.Router();
+const STATUSES = Orders.ORDER_STATUSES || ['draft', 'issued', 'receiving', 'received', 'cancelled'];
 
-router.get('/', async (req, res) => {
+function normalizeDate(input) {
+  if (!input) return null;
+  const date = new Date(input);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString().slice(0, 10);
+}
+
+router.get('/', async (_req, res) => {
   try {
     const orders = await Orders.getAll();
     res.json(orders);
   } catch (err) {
+    console.error('orders.list.error', err);
     res.status(500).json({ error: 'Failed to fetch orders' });
   }
 });
 
 router.get('/:id', async (req, res) => {
   try {
-    const order = await Orders.findById(req.params.id);
+    const order = await Orders.findById(Number(req.params.id));
     if (!order) {
       return res.status(404).json({ error: 'Order not found' });
     }
     res.json(order);
   } catch (err) {
+    console.error('orders.detail.error', err);
     res.status(500).json({ error: 'Failed to fetch order' });
   }
 });
 
 router.post('/', async (req, res) => {
   try {
-    const order = await Orders.create(req.body);
-    res.status(201).json(order);
+    const {
+      po_number,
+      total,
+      vendor_id,
+      vendor_name,
+      vendor,
+      status,
+      request_id,
+      expected_date,
+      notes,
+    } = req.body || {};
+
+    const amount = Number(total);
+    if (Number.isNaN(amount) || amount < 0) {
+      return res.status(400).json({ error: 'Invalid total amount' });
+    }
+
+    let vendorId = vendor_id === undefined || vendor_id === null ? null : Number(vendor_id);
+    if (vendorId !== null && Number.isNaN(vendorId)) {
+      return res.status(400).json({ error: 'Invalid vendor id' });
+    }
+
+    let vendorName = vendor_name || vendor || null;
+    if (vendorId !== null) {
+      const vendorRes = await query('SELECT id, name FROM vendors WHERE id=$1', [vendorId]);
+      if (!vendorRes.rowCount) {
+        return res.status(404).json({ error: 'Vendor not found' });
+      }
+      vendorName = vendorRes.rows[0].name;
+    }
+
+    if (!vendorName) {
+      return res.status(400).json({ error: 'Vendor name required' });
+    }
+
+    const statusValue = typeof status === 'string' ? status.toLowerCase() : 'draft';
+    if (status && !STATUSES.includes(statusValue)) {
+      return res.status(400).json({ error: 'Invalid status' });
+    }
+
+    let requestId = request_id === undefined || request_id === null ? null : Number(request_id);
+    if (requestId !== null && Number.isNaN(requestId)) {
+      return res.status(400).json({ error: 'Invalid request id' });
+    }
+
+    const created = await Orders.create({
+      po_number: po_number ? String(po_number).trim() : null,
+      vendor_name: String(vendorName).trim(),
+      vendor_id: vendorId,
+      total: amount,
+      status: statusValue || 'draft',
+      request_id: requestId,
+      expected_date: normalizeDate(expected_date),
+      notes:
+        notes === undefined || notes === null ? null : String(notes).trim() || null,
+    });
+
+    res.status(201).json(created);
   } catch (err) {
-    res.status(400).json({ error: 'Failed to create order' });
+    console.error('orders.create.error', err);
+    res.status(500).json({ error: 'Failed to create order' });
   }
 });
 
 router.put('/:id', async (req, res) => {
   try {
-    const order = await Orders.update(req.params.id, req.body);
-    if (!order) {
+    const id = Number(req.params.id);
+    if (Number.isNaN(id)) {
+      return res.status(400).json({ error: 'Invalid order id' });
+    }
+
+    const {
+      po_number,
+      total,
+      vendor_id,
+      vendor_name,
+      vendor,
+      status,
+      request_id,
+      expected_date,
+      notes,
+    } = req.body || {};
+
+    const updates = {};
+
+    if (po_number !== undefined) {
+      updates.po_number = po_number ? String(po_number).trim() : null;
+    }
+
+    if (total !== undefined) {
+      const amount = Number(total);
+      if (Number.isNaN(amount) || amount < 0) {
+        return res.status(400).json({ error: 'Invalid total amount' });
+      }
+      updates.total = amount;
+    }
+
+    if (vendor_id !== undefined) {
+      if (vendor_id === null || vendor_id === '') {
+        updates.vendor_id = null;
+      } else {
+        const vendorId = Number(vendor_id);
+        if (Number.isNaN(vendorId)) {
+          return res.status(400).json({ error: 'Invalid vendor id' });
+        }
+        const vendorRes = await query('SELECT id, name FROM vendors WHERE id=$1', [vendorId]);
+        if (!vendorRes.rowCount) {
+          return res.status(404).json({ error: 'Vendor not found' });
+        }
+        updates.vendor_id = vendorId;
+        updates.vendor_name = vendorRes.rows[0].name;
+      }
+    }
+
+    if (vendor_name !== undefined || vendor !== undefined) {
+      const name = vendor_name || vendor;
+      if (name && String(name).trim()) {
+        updates.vendor_name = String(name).trim();
+      } else {
+        return res.status(400).json({ error: 'Vendor name required' });
+      }
+    }
+
+    if (status !== undefined) {
+      const statusValue = typeof status === 'string' ? status.toLowerCase() : '';
+      if (!STATUSES.includes(statusValue)) {
+        return res.status(400).json({ error: 'Invalid status' });
+      }
+      updates.status = statusValue;
+    }
+
+    if (request_id !== undefined) {
+      if (request_id === null || request_id === '') {
+        updates.request_id = null;
+      } else {
+        const requestId = Number(request_id);
+        if (Number.isNaN(requestId)) {
+          return res.status(400).json({ error: 'Invalid request id' });
+        }
+        updates.request_id = requestId;
+      }
+    }
+
+    if (expected_date !== undefined) {
+      updates.expected_date = normalizeDate(expected_date);
+    }
+
+    if (notes !== undefined) {
+      updates.notes =
+        notes === null ? null : String(notes).trim() || null;
+    }
+
+    const updated = await Orders.update(id, updates);
+    if (!updated) {
       return res.status(404).json({ error: 'Order not found' });
     }
-    res.json(order);
+
+    res.json(updated);
   } catch (err) {
-    res.status(400).json({ error: 'Failed to update order' });
+    console.error('orders.update.error', err);
+    res.status(500).json({ error: 'Failed to update order' });
   }
 });
 
 router.delete('/:id', async (req, res) => {
   try {
-    const success = await Orders.remove(req.params.id);
+    const id = Number(req.params.id);
+    if (Number.isNaN(id)) {
+      return res.status(400).json({ error: 'Invalid order id' });
+    }
+
+    const success = await Orders.remove(id);
     if (!success) {
       return res.status(404).json({ error: 'Order not found' });
     }
+
     res.status(204).end();
   } catch (err) {
+    console.error('orders.delete.error', err);
     res.status(500).json({ error: 'Failed to delete order' });
   }
 });

--- a/backend/seed_demo.js
+++ b/backend/seed_demo.js
@@ -50,6 +50,83 @@ async function run(){
         (SELECT id FROM users WHERE email='alex@demo.co'), NOW() - INTERVAL '20 days')
     ) AS t(title,amount,status,category_id,vendor_id,po_number,requester_id,created_at)
     ON CONFLICT DO NOTHING;`);
+
+  const vendors = await pool.query('SELECT id,name FROM vendors');
+  const vendorByName = new Map(vendors.rows.map((row) => [row.name, row]));
+  const requests = await pool.query('SELECT id,title,po_number FROM requests');
+  const requestByPo = new Map();
+  const requestByTitle = new Map();
+  for (const row of requests.rows) {
+    if (row.po_number) requestByPo.set(row.po_number, row);
+    if (row.title) requestByTitle.set(row.title, row);
+  }
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  function dateFromOffset(offsetDays = 0) {
+    const d = new Date(today);
+    d.setDate(d.getDate() + offsetDays);
+    return d.toISOString().slice(0, 10);
+  }
+
+  const sampleOrders = [
+    {
+      poNumber: 'PO-00495',
+      vendorName: 'Apple',
+      requestPo: 'PO-00495',
+      total: 2299.99,
+      status: 'received',
+      expectedOffset: -2,
+      notes: 'MacBook delivered and receipted.',
+    },
+    {
+      poNumber: 'PO-00501',
+      vendorName: 'Adobe',
+      requestTitle: 'Adobe Creative Cloud',
+      total: 79.99,
+      status: 'issued',
+      expectedOffset: 3,
+      notes: 'Renewal sent to vendor.',
+    },
+    {
+      poNumber: 'PO-00512',
+      vendorName: 'Staples',
+      requestTitle: 'Office chairs',
+      total: 1020.0,
+      status: 'draft',
+      expectedOffset: 10,
+      notes: 'Waiting for revised shipping quote.',
+    },
+  ];
+
+  for (const po of sampleOrders) {
+    const vendorRow = vendorByName.get(po.vendorName) || null;
+    const vendorId = vendorRow ? vendorRow.id : null;
+    const vendorName = vendorRow ? vendorRow.name : po.vendorName;
+
+    let requestId = null;
+    if (po.requestPo && requestByPo.has(po.requestPo)) {
+      requestId = requestByPo.get(po.requestPo).id;
+    } else if (po.requestTitle && requestByTitle.has(po.requestTitle)) {
+      requestId = requestByTitle.get(po.requestTitle).id;
+    }
+
+    await pool.query(
+      `INSERT INTO purchase_orders (po_number, vendor, vendor_id, request_id, total, status, expected_date, notes)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+       ON CONFLICT (po_number) DO NOTHING`,
+      [
+        po.poNumber,
+        vendorName,
+        vendorId,
+        requestId,
+        po.total,
+        po.status,
+        dateFromOffset(po.expectedOffset),
+        po.notes,
+      ]
+    );
+  }
   console.log('✅ demo data seeded');
   await pool.end();
 }

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -63,3 +63,24 @@ export async function apiUpload(path, file) {
   if (!res.ok) throw new Error(`UPLOAD ${url} ${res.status} ${res.statusText} :: ${JSON.stringify(await parseOrText(res))}`);
   return res.json();
 }
+
+export async function apiDelete(path) {
+  const url = join(RAW_BASE, path);
+  const res = await fetch(url, {
+    method: "DELETE",
+    headers: { ...authHeader() },
+  });
+  if (!res.ok && res.status !== 204) {
+    throw new Error(
+      `DELETE ${url} ${res.status} ${res.statusText} :: ${JSON.stringify(await parseOrText(res))}`
+    );
+  }
+  if (res.status === 204) return null;
+  const text = await res.text().catch(() => '');
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { _raw: text };
+  }
+}

--- a/frontend/src/pages/PurchaseOrders.jsx
+++ b/frontend/src/pages/PurchaseOrders.jsx
@@ -4,21 +4,51 @@ import { T, Th, Td } from "../components/Table";
 import Button from "../components/Button";
 import Badge from "../components/Badge";
 import SkeletonRow from "../components/SkeletonRow";
-import { apiGet } from "../lib/api";
+import Drawer from "../components/Drawer";
+import { useToast } from "../components/toast";
+import { apiDelete, apiGet, apiPatch, apiPost } from "../lib/api";
+
+const ORDER_STATUSES = ["draft", "issued", "receiving", "received", "cancelled"];
+const INITIAL_FORM = {
+  poNumber: "",
+  vendorId: "",
+  vendorName: "",
+  total: "",
+  status: "draft",
+  requestId: "",
+  expectedDate: "",
+  notes: "",
+};
 
 export default function PurchaseOrders() {
+  const toast = useToast();
   const [orders, setOrders] = useState([]);
+  const [vendors, setVendors] = useState([]);
+  const [requests, setRequests] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [search, setSearch] = useState("");
+
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [editing, setEditing] = useState(null);
+  const [form, setForm] = useState(INITIAL_FORM);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
     setError("");
     try {
-      const data = await apiGet("/api/orders");
-      setOrders(Array.isArray(data) ? data : []);
+      const [ordersRes, vendorsRes, requestsRes] = await Promise.all([
+        apiGet("/api/orders"),
+        apiGet("/api/vendors").catch(() => []),
+        apiGet("/api/requests").catch(() => []),
+      ]);
+      setOrders(Array.isArray(ordersRes) ? ordersRes : []);
+      if (Array.isArray(vendorsRes)) setVendors(vendorsRes);
+      if (Array.isArray(requestsRes)) setRequests(requestsRes);
     } catch (e) {
+      console.error(e);
       setOrders([]);
       setError(e?.message || "Unable to fetch purchase orders.");
     } finally {
@@ -29,6 +59,18 @@ export default function PurchaseOrders() {
   useEffect(() => {
     load();
   }, [load]);
+
+  const vendorOptions = useMemo(() => {
+    return [...vendors].sort((a, b) => a.name.localeCompare(b.name));
+  }, [vendors]);
+
+  const requestOptions = useMemo(() => {
+    return [...requests].sort((a, b) => {
+      const aDate = a?.created_at ? new Date(a.created_at).getTime() : 0;
+      const bDate = b?.created_at ? new Date(b.created_at).getTime() : 0;
+      return bDate - aDate;
+    });
+  }, [requests]);
 
   const filtered = useMemo(() => {
     const list = Array.isArray(orders) ? orders : [];
@@ -53,6 +95,153 @@ export default function PurchaseOrders() {
     ? "No purchase orders match your search."
     : "No purchase orders yet.";
 
+  function openNewDrawer() {
+    setEditing(null);
+    setForm({ ...INITIAL_FORM });
+    setDrawerOpen(true);
+  }
+
+  function openEditDrawer(order) {
+    if (!order) return;
+    const poNumber =
+      pickField(order, ["po_number", "poNumber", "number"]) ?? "";
+    const vendorIdRaw = pickField(order, ["vendor_id", "vendorId"]);
+    const vendorName =
+      pickField(order, ["vendor_name", "vendor", "vendorName"]) || "";
+    const totalRaw = pickField(order, ["total", "amount", "value"]);
+    const statusRaw = pickField(order, ["status", "state", "stage"]);
+    const requestIdRaw = pickField(order, ["request_id", "requestId"]);
+    const expectedRaw = pickField(order, [
+      "expected_date",
+      "expectedDate",
+      "due_date",
+      "dueDate",
+      "delivery_date",
+      "deliveryDate",
+    ]);
+    const notesRaw = pickField(order, ["notes", "memo", "comment"]) || "";
+
+    let expectedDate = "";
+    if (expectedRaw) {
+      const date = new Date(expectedRaw);
+      if (!Number.isNaN(date.getTime())) {
+        expectedDate = date.toISOString().slice(0, 10);
+      }
+    }
+
+    setEditing(order);
+    setForm({
+      poNumber: poNumber || "",
+      vendorId: vendorIdRaw ? String(vendorIdRaw) : "",
+      vendorName: vendorName || "",
+      total:
+        totalRaw !== undefined && totalRaw !== null && totalRaw !== ""
+          ? String(totalRaw)
+          : "",
+      status:
+        typeof statusRaw === "string" && ORDER_STATUSES.includes(statusRaw.toLowerCase())
+          ? statusRaw.toLowerCase()
+          : "draft",
+      requestId: requestIdRaw ? String(requestIdRaw) : "",
+      expectedDate,
+      notes: notesRaw || "",
+    });
+    setDrawerOpen(true);
+  }
+
+  function closeDrawer() {
+    setDrawerOpen(false);
+    setEditing(null);
+    setForm({ ...INITIAL_FORM });
+    setSaving(false);
+    setDeleting(false);
+  }
+
+  function handleVendorSelect(event) {
+    const value = event.target.value;
+    const vendor = vendorOptions.find((v) => String(v.id) === value);
+    setForm((prev) => ({
+      ...prev,
+      vendorId: value,
+      vendorName: vendor ? vendor.name : prev.vendorName,
+    }));
+  }
+
+  async function handleSubmit(event) {
+    event?.preventDefault();
+    if (saving) return;
+
+    const amount = Number(form.total);
+    if (Number.isNaN(amount) || amount < 0) {
+      toast?.error?.("Enter a valid total amount");
+      return;
+    }
+
+    const vendorName = form.vendorName.trim();
+    if (!vendorName && !form.vendorId) {
+      toast?.error?.("Vendor name is required");
+      return;
+    }
+
+    if (!ORDER_STATUSES.includes(form.status)) {
+      toast?.error?.("Choose a valid status");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const payload = {
+        po_number: form.poNumber.trim() || null,
+        total: amount,
+        status: form.status,
+        vendor_id: form.vendorId ? Number(form.vendorId) : null,
+        vendor_name: vendorName || undefined,
+        request_id: form.requestId ? Number(form.requestId) : null,
+        expected_date: form.expectedDate || null,
+        notes: form.notes.trim() ? form.notes.trim() : null,
+      };
+
+      if (editing?.id) {
+        await apiPatch(`/api/orders/${editing.id}`, payload);
+        toast?.success?.("Purchase order updated");
+      } else {
+        await apiPost("/api/orders", payload);
+        toast?.success?.("Purchase order created");
+      }
+
+      await load();
+      closeDrawer();
+    } catch (err) {
+      console.error(err);
+      toast?.error?.("Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    if (!editing?.id || deleting) return;
+    // eslint-disable-next-line no-alert
+    const confirmed = typeof window !== "undefined" ? window.confirm("Delete this purchase order?") : true;
+    if (!confirmed) return;
+    setDeleting(true);
+    try {
+      await apiDelete(`/api/orders/${editing.id}`);
+      toast?.success?.("Purchase order deleted");
+      await load();
+      closeDrawer();
+    } catch (err) {
+      console.error(err);
+      toast?.error?.("Delete failed");
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  const editingLabel = editing
+    ? pickField(editing, ["po_number", "poNumber", "number", "id"]) || editing.id
+    : "";
+
   return (
     <div className="space-y-4">
       <Card>
@@ -60,7 +249,7 @@ export default function PurchaseOrders() {
           title="Purchase orders"
           subtitle="Monitor issued POs and vendor fulfilment"
           actions={(
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               <input
                 className="w-56 rounded-lg border px-3 py-2 text-sm"
                 placeholder="Search PO, vendor, status…"
@@ -69,6 +258,9 @@ export default function PurchaseOrders() {
               />
               <Button variant="ghost" onClick={load} disabled={loading}>
                 Refresh
+              </Button>
+              <Button onClick={openNewDrawer} disabled={loading}>
+                New PO
               </Button>
             </div>
           )}
@@ -88,12 +280,13 @@ export default function PurchaseOrders() {
                   <Th align="right">Total</Th>
                   <Th align="center">Status</Th>
                   <Th align="left">Updated</Th>
+                  <Th align="right">Actions</Th>
                 </tr>
               </thead>
               <tbody>
                 {loading &&
                   Array.from({ length: 5 }).map((_, i) => (
-                    <SkeletonRow key={i} cols={5} />
+                    <SkeletonRow key={i} cols={6} />
                   ))}
                 {!loading &&
                   filtered.map((order, idx) => {
@@ -165,17 +358,23 @@ export default function PurchaseOrders() {
                         <Td>
                           <div>{updated}</div>
                           {dueRaw && (
-                            <div className="text-xs text-slate-500">
-                              Due {due}
-                            </div>
+                            <div className="text-xs text-slate-500">Due {due}</div>
                           )}
+                        </Td>
+                        <Td align="right">
+                          <Button
+                            variant="ghost"
+                            onClick={() => openEditDrawer(order)}
+                          >
+                            Edit
+                          </Button>
                         </Td>
                       </tr>
                     );
                   })}
                 {!loading && !filtered.length && (
                   <tr>
-                    <Td colSpan="5" className="py-6 text-center text-slate-500">
+                    <Td colSpan="6" className="py-6 text-center text-slate-500">
                       {emptyMessage}
                     </Td>
                   </tr>
@@ -185,6 +384,165 @@ export default function PurchaseOrders() {
           </div>
         </CardBody>
       </Card>
+
+      <Drawer
+        open={drawerOpen}
+        title={
+          editing
+            ? `Edit purchase order ${editingLabel}`
+            : "New purchase order"
+        }
+        onClose={closeDrawer}
+        footer={(
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            {editing ? (
+              <Button
+                variant="danger"
+                onClick={handleDelete}
+                disabled={saving || deleting}
+              >
+                {deleting ? "Deleting…" : "Delete"}
+              </Button>
+            ) : (
+              <span />
+            )}
+            <div className="flex items-center gap-2">
+              <Button
+                variant="ghost"
+                type="button"
+                onClick={closeDrawer}
+                disabled={saving || deleting}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                onClick={handleSubmit}
+                disabled={saving || deleting}
+              >
+                {saving ? "Saving…" : editing ? "Save changes" : "Create PO"}
+              </Button>
+            </div>
+          </div>
+        )}
+      >
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="mb-1 block text-sm text-slate-600">PO number</label>
+            <input
+              className="w-full rounded-lg border px-3 py-2"
+              value={form.poNumber}
+              onChange={(e) => setForm((prev) => ({ ...prev, poNumber: e.target.value }))}
+              placeholder="PO-00510"
+            />
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label className="mb-1 block text-sm text-slate-600">Vendor</label>
+              <select
+                className="w-full rounded-lg border px-3 py-2"
+                value={form.vendorId}
+                onChange={handleVendorSelect}
+              >
+                <option value="">Select vendor…</option>
+                {vendorOptions.map((vendor) => (
+                  <option key={vendor.id} value={vendor.id}>
+                    {vendor.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="mb-1 block text-sm text-slate-600">
+                Vendor name
+              </label>
+              <input
+                className="w-full rounded-lg border px-3 py-2"
+                value={form.vendorName}
+                onChange={(e) =>
+                  setForm((prev) => ({ ...prev, vendorName: e.target.value }))
+                }
+                placeholder="Acme Corporation"
+                required={!form.vendorId}
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label className="mb-1 block text-sm text-slate-600">Total</label>
+              <input
+                className="w-full rounded-lg border px-3 py-2"
+                type="number"
+                min="0"
+                step="0.01"
+                value={form.total}
+                onChange={(e) => setForm((prev) => ({ ...prev, total: e.target.value }))}
+                placeholder="1299.99"
+                required
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-sm text-slate-600">Status</label>
+              <select
+                className="w-full rounded-lg border px-3 py-2"
+                value={form.status}
+                onChange={(e) => setForm((prev) => ({ ...prev, status: e.target.value }))}
+              >
+                {ORDER_STATUSES.map((status) => (
+                  <option key={status} value={status}>
+                    {status.charAt(0).toUpperCase() + status.slice(1)}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label className="mb-1 block text-sm text-slate-600">Linked request</label>
+            <select
+              className="w-full rounded-lg border px-3 py-2"
+              value={form.requestId}
+              onChange={(e) => setForm((prev) => ({ ...prev, requestId: e.target.value }))}
+            >
+              <option value="">(no linked request)</option>
+              {requestOptions.map((request) => (
+                <option key={request.id} value={request.id}>
+                  {request.title || `Request #${request.id}`}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label className="mb-1 block text-sm text-slate-600">
+                Expected delivery
+              </label>
+              <input
+                className="w-full rounded-lg border px-3 py-2"
+                type="date"
+                value={form.expectedDate}
+                onChange={(e) =>
+                  setForm((prev) => ({ ...prev, expectedDate: e.target.value }))
+                }
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="mb-1 block text-sm text-slate-600">Notes</label>
+            <textarea
+              className="w-full rounded-lg border px-3 py-2"
+              rows={3}
+              value={form.notes}
+              onChange={(e) => setForm((prev) => ({ ...prev, notes: e.target.value }))}
+              placeholder="Share delivery expectations, payment terms…"
+            />
+          </div>
+        </form>
+      </Drawer>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- extend the backend schema and models to support full purchase order CRUD via PostgreSQL
- seed demo purchase orders and expose delete support in the frontend API helper
- refresh the purchase orders page with a drawer workflow for creating and editing records

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cd66cfbab0832a9d8b35bddf09e369