### PR TITLE
Highlight purchasing priorities in requirements doc

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,5 +1,12 @@
 # Procurement Management Requirements
 
+## Core Purchasing Priorities
+
+- **Purchase order lifecycle is the heartbeat of the product.** Every request must seamlessly transform into a purchase order with rich tracking, change control, and auditability until the order is closed.
+- **Robust catalog experiences drive compliant shopping.** Buyers and requesters rely on curated internal catalogues and vendor-managed content to select approved goods and services quickly.
+- **Punchout to supplier websites is first-class.** The platform needs native punchout flows that let users shop on supplier sites and return carts without breaking the approval process.
+- **Integration keeps procurement connected.** APIs, webhooks, EDI, and ERP connectors synchronize purchase orders, receipts, and invoices with the broader finance ecosystem.
+
 ## Roles and Permissions
 
 ### Finance
@@ -48,5 +55,28 @@
 2. Finance verifies budget availability for approved requests.
 
 ### Purchasing
-1. Buyer converts an approved request into a purchase order and selects a vendor.
-2. Purchase order is tracked until goods or services are received and confirmed.
+1. Buyer converts an approved request into a draft purchase order. Request metadata (vendor recommendations, budget codes, ship-to/bill-to locations, and contract references) auto-populate the header while line items inherit catalogue data and requester notes.
+2. Buyer reviews and enriches the purchase order by adjusting quantities, delivery schedules, or accounting splits. Supporting documents (quotes, scope statements) can be attached at both header and line levels.
+3. Purchase order statuses follow a controlled lifecycle: **Draft → Pending Approval → Approved → Sent to Supplier → Partially Received → Fully Received → Closed**. Change orders produce a new revision while keeping a complete history.
+4. Once approved, the system issues the purchase order via email, portal download, or EDI/cXML transmission. Buyers can resend, acknowledge supplier confirmations, and record order comments.
+5. Goods receipt and service confirmation updates roll back into the purchase order, enabling three-way match readiness for Finance and highlighting variances for investigation.
+
+## Catalogue Management
+
+- Maintain an internal corporate catalogue with category hierarchy, preferred suppliers, contract numbers, pricing tiers, and unit of measure standards.
+- Support vendor-managed catalogue feeds (CSV, cXML, API) with effective dates, price break rules, and automatic change logs that alert buyers before publishing updates.
+- Allow requesters to search, filter, and compare catalogue items, mark favorites, and initiate purchase requests with pre-approved data that speeds up downstream purchase order creation.
+- Provide governance controls such as draft/publish workflows, mandatory attributes, and visibility rules (by business unit, location, or cost center) so catalogue content reflects policy.
+
+## Punchout and External Shopping
+
+- Offer seamless punchout experiences using common protocols (cXML, OCI). Users launch supplier storefronts from within the procurement app, authenticate via SSO, and retain their identity throughout the session.
+- After shopping, the supplier returns the cart to the procurement system where items are converted into line items on a requisition or directly into a draft purchase order while preserving supplier-provided item IDs, pricing, and contract references.
+- Capture punchout transaction logs, timestamps, and cart details for audit trails and troubleshooting. Buyers can replay punchout carts or switch suppliers mid-process without losing the request history.
+
+## Integration and Data Exchange
+
+- Provide REST and GraphQL APIs for CRUD operations on purchase orders, requisitions, catalogue items, suppliers, and receipts. Include webhook callbacks for order approvals, status changes, and receipt postings.
+- Deliver ERP integrations (e.g., SAP, Oracle, NetSuite, Microsoft Dynamics) to push approved purchase orders, synchronize vendor master data, and import goods receipt or invoice status updates.
+- Support supplier integrations using standards such as EDI 850/855/856 and cXML order confirmation/ship notices to minimize manual follow-up.
+- Enable scheduled exports (SFTP, cloud storage) for finance data warehouses and allow import jobs for contract price lists, account codes, and cost center hierarchies.


### PR DESCRIPTION
## Summary
- emphasize the purchase order lifecycle as the central workflow in the procurement requirements
- add catalogue management expectations for internal and vendor-managed content
- document punchout shopping and integration capabilities needed to connect suppliers and ERPs

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd6f480950832a8f16b2f442366610