### PR TITLE
Fix API base URL joining to restore auth requests

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@ publish = "dist"
 
 [build.environment]
 # Your Render backend base URL for production
-VITE_API_BASE = "https://procurementsmanagement.onrender.com/api"
+VITE_API_BASE = "https://procurementsmanagement.onrender.com"
 
 # SPA: route all paths to index.html so deep links work
 [[redirects]]


### PR DESCRIPTION
## Summary
- update the frontend API helper to avoid duplicating overlapping path segments when combining VITE_API_BASE with request paths
- correct the Netlify production VITE_API_BASE so it points to the backend root instead of the /api prefix

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd707e4eb8832aa89719b412f08f0d