### PR TITLE
Fix signup to return session token

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -13,6 +13,7 @@ app.get('/', (req, res) => {
 });
 
 app.use('/auth', authRoutes);
+app.use('/api/auth', authRoutes);
 
 app.use(
   '/api/requests',

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -2,6 +2,12 @@ const jwt = require('jsonwebtoken');
 
 const secret = process.env.JWT_SECRET || 'secretkey';
 
+function normalizeRole(role) {
+  return String(role || '')
+    .trim()
+    .toLowerCase();
+}
+
 const authenticate = (req, res, next) => {
   const header = req.headers.authorization;
   if (!header) {
@@ -25,7 +31,9 @@ const authenticate = (req, res, next) => {
 const authorize =
   (roles = []) =>
   (req, res, next) => {
-    if (roles.length && !roles.includes(req.user.role)) {
+    const allowed = roles.map(normalizeRole).filter(Boolean);
+    const currentRole = normalizeRole(req.user && req.user.role);
+    if (allowed.length && !allowed.includes(currentRole)) {
       return res.status(403).json({ error: 'Forbidden' });
     }
     next();

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -7,27 +7,70 @@ const router = express.Router();
 const users = [];
 const secret = process.env.JWT_SECRET || 'secretkey';
 
-router.post('/register', (req, res) => {
-  const { username, password, role } = req.body;
-  if (!username || !password || !role) {
+function normalizeEmail(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase();
+}
+
+function normalizeRole(value) {
+  const allowed = ['admin', 'approver', 'buyer', 'finance', 'requester'];
+  const role = String(value || '')
+    .trim()
+    .toLowerCase();
+  return allowed.includes(role) ? role : 'requester';
+}
+
+function responseUser(user) {
+  return { id: user.id, email: user.email, role: user.role };
+}
+
+function issueToken(user) {
+  return jwt.sign(responseUser(user), secret, { expiresIn: '1h' });
+}
+
+function handleSignup(req, res) {
+  const { email, username, password, role } = req.body || {};
+  const identifier = normalizeEmail(email || username);
+
+  if (!identifier || !password) {
     return res
       .status(400)
-      .json({ error: 'username, password and role are required' });
+      .json({ error: 'email and password are required' });
   }
 
-  const existingUser = users.find((u) => u.username === username);
+  const existingUser = users.find((u) => u.email === identifier);
   if (existingUser) {
     return res.status(409).json({ error: 'User already exists' });
   }
 
   const hashed = bcrypt.hashSync(password, 10);
-  users.push({ id: users.length + 1, username, password: hashed, role });
-  return res.status(201).json({ message: 'User registered' });
-});
+  const user = {
+    id: users.length + 1,
+    email: identifier,
+    password: hashed,
+    role: normalizeRole(role),
+  };
+  users.push(user);
+
+  const token = issueToken(user);
+  return res.status(201).json({ token, user: responseUser(user) });
+}
+
+router.post('/register', handleSignup);
+router.post('/signup', handleSignup);
 
 router.post('/login', (req, res) => {
-  const { username, password } = req.body;
-  const user = users.find((u) => u.username === username);
+  const { email, username, password } = req.body || {};
+  const identifier = normalizeEmail(email || username);
+
+  if (!identifier || !password) {
+    return res
+      .status(400)
+      .json({ error: 'email and password are required' });
+  }
+
+  const user = users.find((u) => u.email === identifier);
   if (!user) {
     return res.status(401).json({ error: 'Invalid credentials' });
   }
@@ -37,10 +80,8 @@ router.post('/login', (req, res) => {
     return res.status(401).json({ error: 'Invalid credentials' });
   }
 
-  const token = jwt.sign({ id: user.id, role: user.role }, secret, {
-    expiresIn: '1h',
-  });
-  return res.json({ token });
+  const token = issueToken(user);
+  return res.json({ token, user: responseUser(user) });
 });
 
 module.exports = router;

--- a/backend/test/app.test.js
+++ b/backend/test/app.test.js
@@ -1,13 +1,23 @@
 const request = require('supertest');
 const app = require('../index');
 
-describe('POST /auth/register', () => {
-  it('registers a new user', async () => {
+describe('POST /api/auth/signup', () => {
+  it('registers a new user and returns a session token', async () => {
     const res = await request(app)
-      .post('/auth/register')
-      .send({ username: 'tester', password: 'password', role: 'Requester' });
+      .post('/api/auth/signup')
+      .send({
+        email: 'tester@example.com',
+        password: 'password',
+        role: 'Requester',
+      });
 
     expect(res.statusCode).toBe(201);
-    expect(res.body).toEqual({ message: 'User registered' });
+    expect(typeof res.body.token).toBe('string');
+    expect(res.body.token.length).toBeGreaterThan(0);
+    expect(res.body.user).toEqual({
+      id: 1,
+      email: 'tester@example.com',
+      role: 'requester',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- align the authentication routes with email-based signup/login and return token plus user payloads for new sessions
- support the `/api/auth` prefix while keeping legacy routes and relax role checks to be case-insensitive
- refresh the backend signup test to cover the new response contract

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdce0680f4832a8de445a139994375