### PR TITLE
Simplify authentication pages

### DIFF
--- a/frontend/src/components/AuthLayout.jsx
+++ b/frontend/src/components/AuthLayout.jsx
@@ -1,100 +1,19 @@
-import { CheckCircle2, ShieldCheck, Sparkles } from "lucide-react";
-
-const defaultHero = {
-  eyebrow: "Procurement OS",
-  heading: "Keep purchasing flowing without friction",
-  description:
-    "Procurement Manager centralizes intake, approvals, and vendor data so teams can move faster with confidence.",
-  highlights: [
-    {
-      icon: CheckCircle2,
-      title: "Track every request",
-      description: "Live status updates keep stakeholders aligned and accountable.",
-    },
-    {
-      icon: ShieldCheck,
-      title: "Stay in policy",
-      description: "Guardrails for onboarding, budgets, and approvals keep spend compliant.",
-    },
-    {
-      icon: Sparkles,
-      title: "Automate the busywork",
-      description: "Guided forms and automation eliminate back-and-forth with requesters.",
-    },
-  ],
-};
-
-export default function AuthLayout({ title, subtitle, children, hero = defaultHero }) {
+export default function AuthLayout({ title, subtitle, children }) {
   return (
-    <div className="relative min-h-screen overflow-hidden bg-slate-50 text-slate-900">
-      <div className="pointer-events-none absolute inset-0">
-        <div className="absolute -left-28 top-[-18%] h-[520px] w-[520px] rounded-full bg-blue-300/30 blur-3xl" />
-        <div className="absolute right-[-12%] top-20 h-[440px] w-[440px] rounded-full bg-sky-200/40 blur-3xl" />
-        <div className="absolute bottom-[-25%] left-1/2 h-[540px] w-[540px] -translate-x-1/2 rounded-full bg-indigo-200/30 blur-3xl" />
-        <div className="absolute inset-0 bg-gradient-to-b from-white/70 via-transparent to-transparent" />
-      </div>
-
-      <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-7xl flex-col px-4 py-12 sm:px-8 lg:flex-row lg:items-center lg:gap-14 lg:px-12">
-        <aside className="hidden w-full max-w-[480px] flex-col gap-12 lg:flex">
-          <div className="rounded-[32px] border border-white/60 bg-white/80 p-12 shadow-[0_32px_120px_-60px_rgba(15,23,42,0.45)] backdrop-blur">
-            <div className="inline-flex items-center gap-2 rounded-full border border-slate-200/60 bg-slate-100 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] text-slate-500">
-              {hero.eyebrow}
-            </div>
-            <h2 className="mt-8 text-4xl font-semibold leading-tight text-slate-900 sm:text-[2.75rem]">
-              {hero.heading}
-            </h2>
-            <p className="mt-6 text-base leading-relaxed text-slate-600">{hero.description}</p>
-            {hero.highlights?.length ? (
-              <ul className="mt-12 space-y-6">
-                {hero.highlights.map(({ icon: Icon, title: highlightTitle, description }, index) => (
-                  <li key={highlightTitle ?? index} className="flex items-start gap-4">
-                    <span className="mt-0.5 rounded-2xl bg-blue-50 p-2 text-blue-600">
-                      <Icon size={18} />
-                    </span>
-                    <div className="space-y-1">
-                      <h3 className="text-base font-semibold text-slate-900">{highlightTitle}</h3>
-                      <p className="text-sm leading-relaxed text-slate-600">{description}</p>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            ) : null}
+    <div className="flex min-h-screen items-center justify-center bg-slate-50 px-4 py-12 text-slate-900">
+      <div className="w-full max-w-md">
+        <div className="rounded-[28px] border border-slate-200 bg-white p-10 shadow-xl">
+          <div className="mb-8 text-center">
+            <span className="text-sm font-semibold uppercase tracking-[0.4em] text-slate-400">Procurement Manager</span>
           </div>
 
-          <div className="rounded-[28px] border border-slate-200/70 bg-white/80 p-8 text-xs uppercase tracking-[0.3em] text-slate-400 backdrop-blur">
-            <span className="block text-[0.7rem] font-semibold text-slate-500">Trusted by modern operations teams</span>
-            <div className="mt-4 flex flex-wrap gap-3 text-[0.82rem] tracking-normal text-slate-500">
-              <span className="rounded-full border border-slate-200/60 px-3 py-1">Northwind Ops</span>
-              <span className="rounded-full border border-slate-200/60 px-3 py-1">Acme Supply</span>
-              <span className="rounded-full border border-slate-200/60 px-3 py-1">Evergreen Labs</span>
-            </div>
+          <div className="space-y-2 text-center">
+            <h1 className="text-3xl font-semibold tracking-tight text-slate-900">{title}</h1>
+            {subtitle ? <p className="text-sm text-slate-500">{subtitle}</p> : null}
           </div>
-        </aside>
 
-        <main className="flex flex-1 items-center justify-center py-10">
-          <div className="w-full max-w-md">
-            <div className="rounded-[32px] border border-white/80 bg-white/95 p-10 text-slate-900 shadow-[0_40px_120px_-50px_rgba(15,23,42,0.35)] backdrop-blur">
-              <div className="flex items-center gap-3 text-slate-500">
-                <span className="grid h-12 w-12 place-items-center rounded-2xl bg-gradient-to-br from-blue-600 via-indigo-500 to-sky-500 text-lg text-white shadow-lg shadow-blue-500/30">
-                  🛒
-                </span>
-                <div>
-                  <span className="text-xs font-semibold uppercase tracking-[0.42em] text-slate-400">Procurement</span>
-                  <div className="text-lg font-semibold text-slate-900">Manager</div>
-                </div>
-              </div>
-
-              <div className="mt-10 space-y-2">
-                <h1 className="text-3xl font-semibold tracking-tight text-slate-900">{title}</h1>
-                {subtitle ? (
-                  <p className="text-sm leading-relaxed text-slate-500">{subtitle}</p>
-                ) : null}
-              </div>
-
-              <div className="mt-10 space-y-6">{children}</div>
-            </div>
-          </div>
-        </main>
+          <div className="mt-8 space-y-6">{children}</div>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -54,7 +54,7 @@ export default function Login() {
   }
 
   return (
-    <AuthLayout title="Welcome back" subtitle="Sign in to your workspace.">
+    <AuthLayout title="Log in">
       <>
         {err ? (
           <div className="rounded-2xl border border-red-200 bg-red-50/90 px-4 py-3 text-sm text-red-600 shadow-sm">
@@ -96,13 +96,10 @@ export default function Login() {
             {loading ? "Signing in…" : "Sign in"}
           </button>
         </form>
-        <p className="text-center text-xs text-slate-500">
-          Locked out? Your workspace admin can help reset access.
-        </p>
         <p className="text-center text-sm text-slate-500">
-          New to Procurement Manager?{" "}
+          Need an account?{" "}
           <Link to="/signup" className="font-medium text-blue-600 hover:text-blue-700">
-            Create an account
+            Create one
           </Link>
         </p>
       </>

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -29,29 +29,6 @@ const buttonClass = [
   "disabled:opacity-80",
 ].join(" ");
 
-const workspaceRoles = [
-  {
-    title: "Finance",
-    badge: "💼",
-    description: "Keep budgets, accruals, and approvals aligned.",
-  },
-  {
-    title: "Approver",
-    badge: "✅",
-    description: "Review context-rich requests and sign off fast.",
-  },
-  {
-    title: "Buyer",
-    badge: "🛍️",
-    description: "Coordinate sourcing and vendor onboarding in one place.",
-  },
-  {
-    title: "Requester",
-    badge: "✉️",
-    description: "Submit needs with guided intake and live status checks.",
-  },
-];
-
 export default function Signup() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -86,10 +63,7 @@ export default function Signup() {
   }
 
   return (
-    <AuthLayout
-      title="Create your workspace"
-      subtitle="You're creating the admin workspace owner account. Invite your team after setup."
-    >
+    <AuthLayout title="Create account">
       <>
         {err ? (
           <div className="rounded-2xl border border-red-200 bg-red-50/90 px-4 py-3 text-sm text-red-600 shadow-sm">
@@ -97,15 +71,6 @@ export default function Signup() {
           </div>
         ) : null}
         <form onSubmit={submit} className="space-y-6">
-          <div className="flex items-start gap-3 rounded-2xl border border-blue-200/80 bg-blue-50/80 p-4 text-sm text-blue-800">
-            <span className="grid h-10 w-10 place-items-center rounded-xl bg-white text-lg shadow-sm">⭐</span>
-            <div className="space-y-1">
-              <p className="text-sm font-semibold text-blue-900">Administrator sign-up</p>
-              <p className="text-xs leading-relaxed text-blue-700/80">
-                You'll invite finance, approver, buyer, and requester teammates once you're inside the workspace.
-              </p>
-            </div>
-          </div>
           <div className="space-y-1.5">
             <label htmlFor="email" className={labelClass}>
               Work email
@@ -140,28 +105,8 @@ export default function Signup() {
             {loading ? "Creating account…" : "Create account"}
           </button>
         </form>
-        <section className="space-y-4 rounded-[28px] border border-slate-200/70 bg-white/80 px-5 py-6 shadow-sm">
-          <div className="flex items-center justify-between">
-            <p className="text-sm font-semibold text-slate-700">Roles you'll add next</p>
-            <span className="text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-400">Workspace</span>
-          </div>
-          <div className="grid gap-3 sm:grid-cols-2">
-            {workspaceRoles.map(({ title, description, badge }) => (
-              <div
-                key={title}
-                className="flex items-start gap-3 rounded-2xl border border-slate-200/70 bg-slate-50/70 p-4"
-              >
-                <span className="grid h-10 w-10 place-items-center rounded-xl bg-white text-lg shadow-sm">{badge}</span>
-                <div className="space-y-1">
-                  <p className="text-sm font-semibold text-slate-700">{title}</p>
-                  <p className="text-xs leading-relaxed text-slate-500">{description}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
         <p className="text-center text-sm text-slate-500">
-          Already using Procurement Manager?{" "}
+          Already have an account?{" "}
           <Link to="/login" className="font-medium text-blue-600 hover:text-blue-700">
             Log in
           </Link>


### PR DESCRIPTION
## Summary
- replace the auth layout's marketing-heavy hero with a minimal centered form card
- streamline the login page copy to just the essential form and sign-up link
- simplify the sign-up page by removing ancillary guidance sections and keeping only the form

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d34d9c21c0832a9471eb4bf87d9892