### PR TITLE
Refine authenticated workspace around purchasing

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,8 +1,91 @@
-import { Outlet, NavLink, useLocation } from "react-router-dom";
-import { LogOut, ShoppingCart, CheckSquare, Settings as Cog, LayoutGrid, LogIn, UserPlus } from "lucide-react";
+import { Outlet, NavLink, useLocation, Link } from "react-router-dom";
+import {
+  LogOut,
+  ShoppingCart,
+  CheckSquare,
+  Settings as Cog,
+  LayoutGrid,
+  LogIn,
+  UserPlus,
+  FileSpreadsheet,
+  Boxes,
+  Handshake,
+  Workflow,
+  Globe2,
+} from "lucide-react";
 import { AnimatePresence, motion } from "framer-motion";
 import ThemeToggle from "./components/ThemeToggle";
 import { useAuth } from "./lib/auth";
+
+const DEFAULT_QUICK_LINKS = [
+  { to: "/app/purchase-orders", label: "Purchase orders", icon: FileSpreadsheet },
+  { to: "/app/catalog", label: "Catalogue", icon: Boxes },
+  { to: "/app/integrations", label: "PunchOut & integrations", icon: Globe2 },
+  { to: "/app/requests", label: "Requests pipeline", icon: Workflow },
+];
+
+const HERO_META = {
+  dashboard: {
+    crumb: "Dashboard",
+    title: "Procurement control center",
+    description:
+      "Monitor spend commitments, catalogue health, and supplier activity in a finance-ready workspace.",
+    quickLinks: DEFAULT_QUICK_LINKS,
+  },
+  "purchase-orders": {
+    crumb: "Purchase orders",
+    title: "Purchase orders",
+    description:
+      "Issue, track, and reconcile the purchase orders that drive your spend commitments.",
+    quickLinks: [
+      DEFAULT_QUICK_LINKS[0],
+      { to: "/app/requests", label: "Approved requests", icon: ShoppingCart },
+      { to: "/app/integrations", label: "Send to ERP", icon: Workflow },
+    ],
+  },
+  catalog: {
+    crumb: "Catalogue",
+    title: "Catalogue",
+    description:
+      "Curate approved items, manage vendor content, and keep teams buying from the right sources.",
+    quickLinks: [
+      DEFAULT_QUICK_LINKS[1],
+      { to: "/app/vendors", label: "Preferred suppliers", icon: Handshake },
+      { to: "/app/integrations", label: "PunchOut connectors", icon: Globe2 },
+    ],
+  },
+  requests: {
+    crumb: "Requests",
+    title: "Requests",
+    description:
+      "Review demand, shepherd approvals, and convert qualified requisitions into purchase orders.",
+  },
+  approvals: {
+    crumb: "Approvals",
+    title: "Approvals",
+    description:
+      "Align stakeholders on spend decisions and keep purchasing compliant with finance controls.",
+  },
+  vendors: {
+    crumb: "Vendors",
+    title: "Vendors",
+    description:
+      "Nurture supplier relationships, track risk, and share procurement-ready data with finance.",
+  },
+  integrations: {
+    crumb: "Integrations",
+    title: "PunchOut & integrations",
+    description:
+      "Connect ERPs, AP automation, and punchout storefronts so purchasing flows straight into finance.",
+    quickLinks: [DEFAULT_QUICK_LINKS[2], DEFAULT_QUICK_LINKS[0], DEFAULT_QUICK_LINKS[1]],
+  },
+  settings: {
+    crumb: "Settings",
+    title: "Settings",
+    description:
+      "Tune approval thresholds, routing, and automation to reflect procurement policy.",
+  },
+};
 
 export default function App() {
   const { user, logout: signOut } = useAuth();
@@ -11,28 +94,61 @@ export default function App() {
     signOut();
   }
 
+  const navItems = [
+    { to: "/app", label: "Dashboard", icon: <LayoutGrid size={18} strokeWidth={1.75} />, end: true },
+    {
+      to: "/app/purchase-orders",
+      label: "Purchase orders",
+      icon: <FileSpreadsheet size={18} strokeWidth={1.75} />,
+    },
+    { to: "/app/catalog", label: "Catalogue", icon: <Boxes size={18} strokeWidth={1.75} /> },
+    { to: "/app/requests", label: "Requests", icon: <ShoppingCart size={18} strokeWidth={1.75} /> },
+    { to: "/app/approvals", label: "Approvals", icon: <CheckSquare size={18} strokeWidth={1.75} /> },
+    { to: "/app/vendors", label: "Vendors", icon: <Handshake size={18} strokeWidth={1.75} /> },
+    { to: "/app/integrations", label: "Integrations", icon: <Workflow size={18} strokeWidth={1.75} /> },
+    { to: "/app/settings", label: "Settings", icon: <Cog size={18} strokeWidth={1.75} /> },
+  ];
+
   return (
-    <div className="min-h-screen gradient-hero text-slate-900 grid md:grid-cols-[240px_1fr]">
+    <div className="min-h-screen bg-slate-100/70 text-slate-900 md:grid md:grid-cols-[260px_1fr]">
       {/* Sidebar */}
-      <aside className="hidden md:flex flex-col border-r border-slate-200 bg-white/70 backdrop-blur">
-        <div className="px-5 py-4 font-bold tracking-wide border-b border-slate-100">🛒 Procurement</div>
-        <nav className="p-3 space-y-1">
-          <Nav to="/app" icon={<LayoutGrid size={16}/>} end>Dashboard</Nav>
-          <Nav to="/app/requests" icon={<ShoppingCart size={16}/>}>Requests</Nav>
-          <Nav to="/app/approvals" icon={<CheckSquare size={16}/>}>Approvals</Nav>
-          <Nav to="/app/settings" icon={<Cog size={16}/>}>Settings</Nav>
-          <Nav to="/app/vendors" icon={<ShoppingCart size={16}/>}>Vendors</Nav>
+      <aside className="hidden min-h-screen md:flex flex-col border-r border-slate-200 bg-white/90 backdrop-blur">
+        <div className="border-b border-slate-200 px-6 py-6">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.32em] text-blue-600">Procurement</div>
+          <div className="mt-2 text-lg font-semibold text-slate-900">Control workspace</div>
+          <p className="mt-2 text-xs leading-relaxed text-slate-500">
+            Purchasing, catalogue, and integrations managed in one place.
+          </p>
+        </div>
+        <nav className="flex-1 space-y-1 px-4 py-4">
+          {navItems.map((item) => (
+            <Nav key={item.to} to={item.to} end={item.end} icon={item.icon}>
+              {item.label}
+            </Nav>
+          ))}
         </nav>
-        <div className="mt-auto p-3 border-t border-slate-100 space-y-2">
+        <div className="space-y-3 border-t border-slate-200 px-6 py-5 text-sm text-slate-600">
           {user ? (
-            <div className="flex items-center justify-between text-sm">
-              <div className="text-slate-600 truncate max-w-[140px]">{user.email}</div>
-              <button onClick={handleLogout} className="inline-flex items-center gap-1 text-slate-700 hover:text-slate-900 press"><LogOut size={16}/> Logout</button>
+            <div className="space-y-2">
+              <div className="text-xs uppercase tracking-wide text-slate-500">Signed in</div>
+              <div className="truncate font-medium text-slate-700" title={user.email}>
+                {user.email}
+              </div>
+              <button
+                onClick={handleLogout}
+                className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-900"
+              >
+                <LogOut size={16} strokeWidth={1.75} /> Sign out
+              </button>
             </div>
           ) : (
             <div className="flex items-center justify-between text-sm">
-              <a className="inline-flex items-center gap-1 text-blue-600 press" href="/login"><LogIn size={16}/> Login</a>
-              <a className="inline-flex items-center gap-1 text-slate-700 press" href="/signup"><UserPlus size={16}/> Sign up</a>
+              <Link className="inline-flex items-center gap-1 text-blue-700" to="/login">
+                <LogIn size={16} strokeWidth={1.75} /> Login
+              </Link>
+              <Link className="inline-flex items-center gap-1 text-slate-700" to="/signup">
+                <UserPlus size={16} strokeWidth={1.75} /> Sign up
+              </Link>
             </div>
           )}
           <ThemeToggle />
@@ -41,23 +157,45 @@ export default function App() {
 
       {/* Main */}
       <div className="flex min-h-screen flex-col">
-        <header className="md:hidden sticky top-0 z-10 bg-white/70 backdrop-blur border-b border-slate-200">
-          <div className="px-4 py-3 font-bold tracking-wide flex items-center justify-between">
-            <span>🛒 Procurement</span>
+        <header className="sticky top-0 z-20 border-b border-slate-200 bg-white/90 backdrop-blur md:hidden">
+          <div className="flex items-center justify-between px-4 py-3">
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-[0.32em] text-blue-600">
+                Procurement
+              </div>
+              <div className="text-base font-semibold text-slate-900">Control workspace</div>
+            </div>
             {user ? (
-              <a className="text-sm text-blue-700" href="/app/requests">Requests</a>
+              <div className="flex items-center gap-2 text-xs font-medium">
+                <Link
+                  className="rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-blue-700"
+                  to="/app/purchase-orders"
+                >
+                  POs
+                </Link>
+                <Link
+                  className="rounded-full border border-slate-200 px-3 py-1 text-slate-600"
+                  to="/app/catalog"
+                >
+                  Catalog
+                </Link>
+              </div>
             ) : (
               <div className="flex items-center gap-3 text-sm">
-                <a className="text-blue-700" href="/login">Login</a>
-                <a className="text-slate-700" href="/signup">Sign up</a>
+                <Link className="text-blue-700" to="/login">
+                  Login
+                </Link>
+                <Link className="text-slate-700" to="/signup">
+                  Sign up
+                </Link>
               </div>
             )}
           </div>
         </header>
 
         <AnimatedOutlet />
-        <footer className="container py-6 text-xs text-slate-500">
-          © {new Date().getFullYear()} Procurement Manager
+        <footer className="px-4 py-6 text-xs text-slate-500 md:px-8">
+          © {new Date().getFullYear()} Procurement workspace
         </footer>
       </div>
     </div>
@@ -67,7 +205,7 @@ export default function App() {
 function AnimatedOutlet() {
   const location = useLocation();
   return (
-    <div className="container py-6">
+    <div className="container mx-auto px-4 py-6 md:px-8">
       <AnimatePresence mode="wait">
         <motion.div
           key={location.pathname}
@@ -86,21 +224,46 @@ function AnimatedOutlet() {
 
 function Hero() {
   const { pathname } = useLocation();
-  const segments = pathname.replace(/^\/+/,'').split('/');
-  let title = segments[0] || 'dashboard';
-  if (title === 'app') {
-    title = segments[1] || 'dashboard';
+  const { user } = useAuth();
+  const segments = pathname.replace(/^\/+/, "").split("/");
+  let key = segments[0] || "dashboard";
+  if (key === "app") {
+    key = segments[1] || "dashboard";
   }
-  if (!title) title = 'dashboard';
-  const pretty = title
-    .split('-')
-    .filter(Boolean)
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ') || 'Dashboard';
+  if (!key) key = "dashboard";
+  const meta = HERO_META[key] || HERO_META.dashboard;
+  const crumb = meta.crumb || meta.title || key;
+  const quickLinks = meta.quickLinks ?? DEFAULT_QUICK_LINKS;
+
   return (
-    <div className="bg-white/70 backdrop-blur border border-slate-200 rounded-2xl p-5">
-      <div className="text-xs text-slate-500">Home / {pretty}</div>
-      <h1 className="text-2xl md:text-3xl font-semibold mt-1">{pretty}</h1>
+    <div className="rounded-2xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur">
+      <div className="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-3">
+          <div className="text-xs uppercase tracking-[0.32em] text-slate-500">Home / {crumb}</div>
+          <h1 className="text-2xl font-semibold text-slate-900 md:text-3xl">{meta.title || crumb}</h1>
+          {meta.description && (
+            <p className="max-w-2xl text-sm leading-relaxed text-slate-600 md:text-base">
+              {meta.description}
+            </p>
+          )}
+        </div>
+        <div className="rounded-xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-sm text-slate-600 md:max-w-xs">
+          <div className="font-semibold text-slate-700">Finance workspace</div>
+          <div className="mt-1 text-xs text-slate-500">
+            {user?.email ? `Signed in as ${user.email}` : "Sign in to manage purchasing."}
+          </div>
+          <p className="mt-3 text-sm leading-relaxed text-slate-600">
+            Keep purchase orders, catalogue governance, and integrations aligned so budgets stay on plan.
+          </p>
+        </div>
+      </div>
+      {Array.isArray(quickLinks) && quickLinks.length > 0 && (
+        <div className="mt-5 flex flex-wrap gap-2">
+          {quickLinks.map((link) => (
+            <QuickLink key={`${link.to}-${link.label}`} {...link} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -111,11 +274,25 @@ function Nav({ to, icon, children, end }) {
       to={to}
       end={end}
       className={({ isActive }) =>
-        "flex items-center gap-2 rounded-lg px-3 py-2 text-sm press " +
-        (isActive ? "bg-white text-blue-700 font-medium shadow-sm" : "text-slate-700 hover:bg-white/60")
+        "flex items-center gap-2 rounded-lg px-3 py-2.5 text-sm font-medium transition " +
+        (isActive
+          ? "bg-blue-50 text-blue-700 shadow-sm"
+          : "text-slate-600 hover:bg-slate-50 hover:text-slate-900")
       }
     >
       {icon}{children}
     </NavLink>
+  );
+}
+
+function QuickLink({ to, label, icon: Icon }) {
+  return (
+    <Link
+      to={to}
+      className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:border-blue-200 hover:bg-blue-50 hover:text-blue-700"
+    >
+      {Icon ? <Icon size={14} strokeWidth={1.75} /> : null}
+      {label}
+    </Link>
   );
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -11,6 +11,9 @@ import RequestDetailRoute from "./pages/RequestDetailRoute";
 import Approvals from "./pages/Approvals";
 import Settings from "./pages/Settings";
 import Vendors from "./pages/Vendors";
+import PurchaseOrders from "./pages/PurchaseOrders";
+import Catalog from "./pages/Catalog";
+import Integrations from "./pages/Integrations";
 import Login from "./pages/Login";
 import Signup from "./pages/Signup";
 import { AuthProvider, RequireAuth } from "./lib/auth";
@@ -36,12 +39,15 @@ ReactDOM.createRoot(document.getElementById("root")).render(
             )}
           >
             <Route index element={<Dashboard />} />
+            <Route path="purchase-orders" element={<PurchaseOrders />} />
+            <Route path="catalog" element={<Catalog />} />
             <Route path="requests" element={<Requests />}>
               <Route path=":id" element={<RequestDetailRoute />} />
             </Route>
             <Route path="approvals" element={<Approvals />} />
             <Route path="settings" element={<Settings />} />
             <Route path="vendors" element={<Vendors />} />
+            <Route path="integrations" element={<Integrations />} />
           </Route>
         </Routes>
       </AuthProvider>

--- a/frontend/src/pages/Catalog.jsx
+++ b/frontend/src/pages/Catalog.jsx
@@ -1,0 +1,303 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  ArrowUpRight,
+  Boxes,
+  FileSpreadsheet,
+  Globe2,
+  Workflow,
+} from "lucide-react";
+import { Card, CardBody, CardHeader } from "../components/Card";
+import { apiGet } from "../lib/api";
+
+export default function Catalog() {
+  const [rawCategories, setRawCategories] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    (async () => {
+      try {
+        const response = await apiGet("/api/categories");
+        if (!active) return;
+        setRawCategories(Array.isArray(response) ? response : []);
+      } catch (err) {
+        console.warn("Failed to load categories", err);
+        if (!active) return;
+        setRawCategories([]);
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const categories = useMemo(() => {
+    return rawCategories
+      .map((category, index) => {
+        const itemCount = safeNumber(
+          category?.item_count ??
+            category?.items_count ??
+            category?.itemCount ??
+            (Array.isArray(category?.items) ? category.items.length : 0)
+        );
+        const punchoutUrl =
+          category?.punchout_url ??
+          category?.punchoutUrl ??
+          category?.punchout?.url ??
+          "";
+        const lastUpdated =
+          category?.updated_at ??
+          category?.updatedAt ??
+          category?.modified_at ??
+          category?.modifiedAt ??
+          category?.created_at ??
+          category?.createdAt ??
+          "";
+        return {
+          id: category?.id ?? index,
+          name: category?.name || `Category ${index + 1}`,
+          itemCount,
+          punchoutUrl,
+          lastUpdated,
+          owner: category?.owner ?? category?.managed_by ?? "",
+        };
+      })
+      .sort((a, b) => b.itemCount - a.itemCount || a.name.localeCompare(b.name));
+  }, [rawCategories]);
+
+  const totalItems = categories.reduce((sum, cat) => sum + cat.itemCount, 0);
+  const punchoutCategories = categories.filter((cat) => Boolean(cat.punchoutUrl));
+  const lastUpdatedTimestamp = categories.reduce(
+    (latest, cat) => {
+      const ts = getTimestamp(cat.lastUpdated);
+      return ts > latest ? ts : latest;
+    },
+    0
+  );
+
+  const summary = {
+    activeCategories: categories.length,
+    totalItems,
+    punchoutCount: punchoutCategories.length,
+    lastUpdatedLabel: lastUpdatedTimestamp
+      ? formatDate(new Date(lastUpdatedTimestamp))
+      : "No updates recorded",
+  };
+
+  const displayCategories = categories.slice(0, 8);
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader
+          title="Catalogue health"
+          subtitle="Ensure buyers see the right items, pricing, and supplier experiences"
+        />
+        <CardBody className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            <Metric
+              icon={Boxes}
+              label="Active categories"
+              value={summary.activeCategories}
+            />
+            <Metric
+              icon={FileSpreadsheet}
+              label="Catalogue items"
+              value={summary.totalItems}
+            />
+            <Metric
+              icon={Globe2}
+              label="PunchOut connectors"
+              value={summary.punchoutCount}
+            />
+            <Metric
+              icon={Workflow}
+              label="Last update"
+              value={summary.lastUpdatedLabel}
+              isText
+            />
+          </div>
+          <p className="text-sm text-slate-600">
+            Keep pricing current, enrich categories with accounting data, and publish only after finance
+            review. Vendor-managed feeds and punchout storefronts can be activated from the integrations hub.
+          </p>
+        </CardBody>
+      </Card>
+
+      <section className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+        <Card>
+          <CardHeader
+            title="Category coverage"
+            subtitle="Curated content that drives compliant purchasing"
+            actions={
+              <Link
+                className="inline-flex items-center gap-1 text-sm font-medium text-blue-700"
+                to="/app/requests"
+              >
+                View demand <ArrowUpRight size={16} />
+              </Link>
+            }
+          />
+          <CardBody className="space-y-3">
+            {displayCategories.length ? (
+              displayCategories.map((category) => (
+                <CategoryRow key={category.id} category={category} />
+              ))
+            ) : (
+              <div className="rounded-2xl border border-dashed border-slate-200 px-4 py-6 text-sm text-slate-500">
+                {loading
+                  ? "Loading catalogue…"
+                  : "Create a category or import a vendor feed to start building your procurement catalogue."}
+              </div>
+            )}
+            {categories.length > displayCategories.length && (
+              <div className="text-xs text-slate-500">
+                Showing the first {displayCategories.length} categories by item count. Manage the full list in
+                the catalogue workspace.
+              </div>
+            )}
+          </CardBody>
+        </Card>
+
+        <Card id="punchout">
+          <CardHeader
+            title="PunchOut & supplier sites"
+            subtitle="Launch external storefronts without breaking the approval process"
+            actions={
+              <Link
+                className="inline-flex items-center gap-1 text-sm font-medium text-blue-700"
+                to="/app/integrations#punchout"
+              >
+                Configure connectors <ArrowUpRight size={16} />
+              </Link>
+            }
+          />
+          <CardBody className="space-y-3">
+            {punchoutCategories.length ? (
+              punchoutCategories.map((category) => (
+                <PunchoutRow key={category.id} category={category} />
+              ))
+            ) : (
+              <div className="rounded-2xl border border-dashed border-slate-200 px-4 py-6 text-sm text-slate-500">
+                {loading
+                  ? "Checking for punchout connectors…"
+                  : "Connect a supplier punchout storefront so buyers can shop on vendor websites and return carts automatically."}
+              </div>
+            )}
+            <div className="rounded-2xl bg-blue-50 px-4 py-3 text-xs text-blue-700">
+              Support cXML and OCI punchout flows with SSO, transaction logs, and automatic cart return into
+              requisitions.
+            </div>
+          </CardBody>
+        </Card>
+      </section>
+
+      <Card>
+        <CardHeader
+          title="Content management playbook"
+          subtitle="Keep catalogue data finance-ready and audit compliant"
+        />
+        <CardBody className="space-y-4 text-sm text-slate-600">
+          <ol className="list-decimal list-inside space-y-3">
+            <li>Review vendor-managed feeds each week and publish updates after finance sign-off.</li>
+            <li>Tag items with category, cost center, and budget codes before making them visible to requesters.</li>
+            <li>Use draft states to stage large updates and share preview links with stakeholders for feedback.</li>
+            <li>Activate punchout connectors when catalogue coverage is insufficient or pricing is dynamic.</li>
+          </ol>
+          <div className="rounded-2xl border border-dashed border-slate-200 px-4 py-3 text-xs text-slate-500">
+            Automate imports and publish workflows through the <Link className="text-blue-700" to="/app/integrations#automation">integrations hub</Link> to keep finance systems synchronized.
+          </div>
+        </CardBody>
+      </Card>
+    </div>
+  );
+}
+
+function Metric({ icon: Icon, label, value, isText }) {
+  const display = isText ? value : Number(value) || 0;
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white px-3 py-3">
+      <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-slate-500">
+        {Icon ? <Icon size={14} strokeWidth={1.75} /> : null}
+        <span>{label}</span>
+      </div>
+      <div className="mt-1 text-xl font-semibold text-slate-900">
+        {isText ? display : display.toLocaleString()}
+      </div>
+    </div>
+  );
+}
+
+function CategoryRow({ category }) {
+  const { name, itemCount, punchoutUrl, lastUpdated, owner } = category;
+  const type = punchoutUrl ? "punchout" : "internal";
+  return (
+    <div className="space-y-2 rounded-2xl border border-slate-200 bg-white px-3 py-3">
+      <div className="flex items-center justify-between gap-3">
+        <span className="font-medium text-slate-800">{name}</span>
+        <span className="text-xs text-slate-500">
+          {lastUpdated ? formatDate(lastUpdated) : "Not updated"}
+        </span>
+      </div>
+      <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
+        <span>{itemCount} item{itemCount === 1 ? "" : "s"}</span>
+        <CategoryBadge type={type} />
+        {owner && <span>Owner: {owner}</span>}
+      </div>
+    </div>
+  );
+}
+
+function PunchoutRow({ category }) {
+  return (
+    <div className="space-y-2 rounded-2xl border border-blue-100 bg-blue-50/60 px-3 py-3">
+      <div className="flex items-center justify-between gap-3">
+        <span className="font-medium text-blue-800">{category.name}</span>
+        <span className="text-xs text-blue-600">
+          {category.lastUpdated ? formatDate(category.lastUpdated) : "Not updated"}
+        </span>
+      </div>
+      <div className="text-xs text-blue-700 break-words">
+        {category.punchoutUrl || "Configured via integrations"}
+      </div>
+    </div>
+  );
+}
+
+function CategoryBadge({ type }) {
+  if (type === "punchout") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-1 text-xs font-medium text-blue-700">
+        PunchOut
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-600">
+      Internal catalogue
+    </span>
+  );
+}
+
+function safeNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) && num > 0 ? Math.round(num) : 0;
+}
+
+function getTimestamp(value) {
+  if (!value) return 0;
+  const date = new Date(value);
+  const time = date.getTime();
+  return Number.isNaN(time) ? 0 : time;
+}
+
+function formatDate(value) {
+  if (!value) return "";
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleDateString();
+}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,73 +1,741 @@
 import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { motion } from "framer-motion";
+import {
+  ArrowUpRight,
+  FileSpreadsheet,
+  Boxes,
+  Workflow,
+  Globe2,
+} from "lucide-react";
 import { apiGet } from "../lib/api";
-import { Card, CardBody } from "../components/Card";
+import { Card, CardBody, CardHeader } from "../components/Card";
 import Counter from "../components/Counter";
 import Badge from "../components/Badge";
-import { motion } from "framer-motion";
 
-export default function Dashboard(){
-  const [reqs,setReqs]=useState([]);
-  const [cats,setCats]=useState([]);
+const QUICK_ACTIONS = [
+  {
+    title: "Raise a purchase order",
+    description:
+      "Turn approved requests into supplier-ready documents with full audit trails.",
+    to: "/app/purchase-orders",
+    icon: FileSpreadsheet,
+  },
+  {
+    title: "Curate the catalogue",
+    description:
+      "Publish preferred items, pricing, and accounting codes for compliant shopping.",
+    to: "/app/catalog",
+    icon: Boxes,
+  },
+  {
+    title: "Launch PunchOut session",
+    description:
+      "Shop supplier storefronts via cXML or OCI without leaving the workspace.",
+    to: "/app/integrations#punchout",
+    icon: Globe2,
+  },
+  {
+    title: "Review integration feed",
+    description:
+      "Keep ERPs and AP automation synced with purchase orders and receipts.",
+    to: "/app/integrations#automation",
+    icon: Workflow,
+  },
+];
 
-  useEffect(()=>{ (async()=>{
-    try {
-      const [r,c]=await Promise.all([apiGet("/api/requests"), apiGet("/api/categories")]);
-      setReqs(r); setCats(c);
-    } catch {}
-  })(); },[]);
+const CONNECTOR_SUMMARY = [
+  {
+    id: "punchout",
+    name: "PunchOut storefronts",
+    status: "Enabled",
+    description:
+      "Launch supplier sites and return carts straight into requisitions without breaking approvals.",
+    detail:
+      "Active suppliers span technology, office, and facilities partners using cXML and OCI standards.",
+    icon: Globe2,
+  },
+  {
+    id: "erp",
+    name: "ERP & AP sync",
+    status: "Connected",
+    description:
+      "Automatically push approved purchase orders and receipts into NetSuite, SAP, or Oracle.",
+    detail: "30-minute exports keep finance, AP automation, and suppliers aligned.",
+    icon: Workflow,
+  },
+  {
+    id: "warehouse",
+    name: "Data warehouse feed",
+    status: "Scheduled",
+    description:
+      "Nightly SFTP and API feeds share spend, vendor, and receipt data with finance analytics.",
+    detail: "Delivered to Snowflake and Power BI with change logs for auditors.",
+    icon: FileSpreadsheet,
+  },
+  {
+    id: "automation",
+    name: "Automation webhooks",
+    status: "Ready",
+    description:
+      "Notify budget owners, approvers, and suppliers in real time when purchasing milestones change.",
+    detail: "Supports Slack, Teams, and custom webhooks for downstream workflows.",
+    icon: Workflow,
+  },
+];
 
-  const kpi = useMemo(()=>({
-    total:reqs.length,
-    approved:reqs.filter(r=>r.status==='approved').length,
-    pending:reqs.filter(r=>r.status==='pending').length,
-    denied:reqs.filter(r=>r.status==='denied').length,
-  }),[reqs]);
+export default function Dashboard() {
+  const [reqs, setReqs] = useState([]);
+  const [cats, setCats] = useState([]);
+  const [orders, setOrders] = useState([]);
+  const [vendors, setVendors] = useState([]);
+  const [loading, setLoading] = useState(true);
 
-  // 👇 this is what was missing
-  const recent = useMemo(()=>{
-    return [...reqs].sort((a,b)=>new Date(b.created_at)-new Date(a.created_at)).slice(0,5);
-  },[reqs]);
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    (async () => {
+      try {
+        const results = await Promise.allSettled([
+          apiGet("/api/requests"),
+          apiGet("/api/categories"),
+          apiGet("/api/orders"),
+          apiGet("/api/vendors"),
+        ]);
+        if (!active) return;
+        const [requestsRes, categoriesRes, ordersRes, vendorsRes] = results;
+        setReqs(
+          requestsRes.status === "fulfilled" && Array.isArray(requestsRes.value)
+            ? requestsRes.value
+            : []
+        );
+        setCats(
+          categoriesRes.status === "fulfilled" && Array.isArray(categoriesRes.value)
+            ? categoriesRes.value
+            : []
+        );
+        setOrders(
+          ordersRes.status === "fulfilled" && Array.isArray(ordersRes.value)
+            ? ordersRes.value
+            : []
+        );
+        setVendors(
+          vendorsRes.status === "fulfilled" && Array.isArray(vendorsRes.value)
+            ? vendorsRes.value
+            : []
+        );
+      } catch (err) {
+        console.warn("Failed to load dashboard data", err);
+        if (!active) return;
+        setReqs([]);
+        setCats([]);
+        setOrders([]);
+        setVendors([]);
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const categoryById = useMemo(() => {
+    const map = new Map();
+    cats.forEach((cat) => {
+      const id = Number(cat?.id);
+      if (!Number.isNaN(id)) {
+        map.set(id, cat);
+      }
+    });
+    return map;
+  }, [cats]);
+
+  const kpi = useMemo(() => ({
+    total: reqs.length,
+    approved: reqs.filter((r) => normalizeStatus(r.status) === "approved").length,
+    pending: reqs.filter((r) => normalizeStatus(r.status) === "pending").length,
+    denied: reqs.filter((r) => normalizeStatus(r.status) === "denied").length,
+  }), [reqs]);
+
+  const spendTotals = useMemo(() => {
+    return reqs.reduce(
+      (acc, req) => {
+        const amount = toNumber(req?.amount);
+        acc.requested += amount;
+        const status = normalizeStatus(req?.status);
+        if (status === "approved") acc.approved += amount;
+        if (status === "pending") acc.pending += amount;
+        return acc;
+      },
+      { requested: 0, approved: 0, pending: 0 }
+    );
+  }, [reqs]);
+
+  const orderStats = useMemo(() => {
+    const stats = {
+      total: 0,
+      open: 0,
+      receiving: 0,
+      closed: 0,
+      cancelled: 0,
+      committed: 0,
+      dueSoon: 0,
+      late: 0,
+    };
+    const now = new Date();
+    const soon = new Date(now);
+    soon.setDate(now.getDate() + 7);
+    const openStatuses = new Set([
+      "draft",
+      "pending",
+      "awaiting-approval",
+      "issued",
+      "sent",
+    ]);
+    const receivingStatuses = new Set([
+      "receiving",
+      "partially-received",
+      "partial",
+    ]);
+    const closedStatuses = new Set([
+      "received",
+      "closed",
+      "complete",
+      "completed",
+      "fulfilled",
+    ]);
+    const cancelledStatuses = new Set(["cancelled", "void", "rejected"]);
+
+    orders.forEach((order) => {
+      stats.total += 1;
+      const status = normalizeStatus(getOrderStatus(order));
+      const total = getOrderTotal(order);
+      stats.committed += total;
+
+      if (receivingStatuses.has(status)) {
+        stats.receiving += 1;
+        stats.open += 1;
+      } else if (closedStatuses.has(status)) {
+        stats.closed += 1;
+      } else if (cancelledStatuses.has(status)) {
+        stats.cancelled += 1;
+      } else if (openStatuses.has(status) || !status) {
+        stats.open += 1;
+      }
+
+      const expected = getExpectedDate(order);
+      if (expected) {
+        if (expected < now && !closedStatuses.has(status) && !cancelledStatuses.has(status)) {
+          stats.late += 1;
+        } else if (expected >= now && expected <= soon) {
+          stats.dueSoon += 1;
+        }
+      }
+    });
+
+    return stats;
+  }, [orders]);
+
+  const categoryTotals = useMemo(() => {
+    const totals = new Map();
+    reqs.forEach((req) => {
+      const categoryId =
+        req?.category_id !== undefined && req?.category_id !== null
+          ? Number(req.category_id)
+          : null;
+      const category = categoryId !== null ? categoryById.get(categoryId) : null;
+      const name = category?.name || req?.category_name || "Uncategorised";
+      const key = categoryId ?? name;
+      const entry = totals.get(key) || {
+        name,
+        amount: 0,
+        count: 0,
+        categoryId,
+      };
+      entry.amount += toNumber(req?.amount);
+      entry.count += 1;
+      totals.set(key, entry);
+    });
+
+    return Array.from(totals.values())
+      .map((entry) => {
+        const source =
+          entry.categoryId !== null ? categoryById.get(entry.categoryId) : null;
+        const itemCount = safeNumber(
+          source?.item_count ??
+            source?.items_count ??
+            (Array.isArray(source?.items) ? source.items.length : 0)
+        );
+        return { ...entry, itemCount };
+      })
+      .sort((a, b) => b.amount - a.amount);
+  }, [reqs, categoryById]);
+
+  const requestedTotal = spendTotals.requested;
+  const topCategories = useMemo(() => {
+    return categoryTotals.slice(0, 4).map((entry) => ({
+      ...entry,
+      percent:
+        requestedTotal > 0
+          ? Math.round((entry.amount / requestedTotal) * 100)
+          : 0,
+    }));
+  }, [categoryTotals, requestedTotal]);
+
+  const recent = useMemo(() => {
+    return [...reqs]
+      .sort(
+        (a, b) =>
+          getTimestamp(b?.updated_at || b?.created_at) -
+          getTimestamp(a?.updated_at || a?.created_at)
+      )
+      .slice(0, 5);
+  }, [reqs]);
+
+  const readyForPo = useMemo(() => {
+    return reqs
+      .filter((req) => normalizeStatus(req.status) === "approved")
+      .sort(
+        (a, b) =>
+          getTimestamp(b?.updated_at || b?.created_at) -
+          getTimestamp(a?.updated_at || a?.created_at)
+      )
+      .slice(0, 5);
+  }, [reqs]);
+
+  const highlightedRequests = useMemo(() => {
+    const base = readyForPo.length ? readyForPo : recent;
+    return base.map((req) => ({
+      ...req,
+      categoryLabel: resolveCategoryName(req, categoryById),
+    }));
+  }, [readyForPo, recent, categoryById]);
+
+  const highlightTitle = readyForPo.length
+    ? "Requests ready for purchase orders"
+    : "Recent requests";
+  const highlightSubtitle = readyForPo.length
+    ? "Convert approvals into committed spend"
+    : "Latest purchasing activity across teams";
+
+  const vendorCount = Array.isArray(vendors) ? vendors.length : 0;
 
   return (
     <div className="space-y-8">
-      <section className="grid grid-cols-2 md:grid-cols-4 gap-3">
-        <Kpi title="Total" value={kpi.total}/>
-        <Kpi title="Approved" value={kpi.approved}/>
-        <Kpi title="Pending" value={kpi.pending}/>
-        <Kpi title="Denied" value={kpi.denied}/>
+      <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <Kpi
+          title="Open purchase orders"
+          value={orderStats.open}
+          hint="Draft, pending, or issued"
+        />
+        <Kpi
+          title="Requests pending approval"
+          value={kpi.pending}
+          hint="Require finance or stakeholder review"
+        />
+        <Kpi
+          title="Active catalogue categories"
+          value={cats.length}
+          hint="Published for compliant shopping"
+        />
+        <Kpi
+          title="Active suppliers"
+          value={vendorCount}
+          hint="Engaged in recent purchasing"
+        />
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+        <Card>
+          <CardHeader
+            title="Purchase orders at a glance"
+            subtitle="Finance-critical visibility into spend commitments"
+            actions={
+              <Link
+                className="inline-flex items-center gap-1 text-sm font-medium text-blue-700"
+                to="/app/purchase-orders"
+              >
+                View register <ArrowUpRight size={16} />
+              </Link>
+            }
+          />
+          <CardBody className="space-y-5">
+            <div className="grid gap-4 md:grid-cols-3">
+              <SummaryTile
+                label="Open"
+                value={orderStats.open}
+                description="Draft, pending approval, or issued"
+              />
+              <SummaryTile
+                label="Receiving"
+                value={orderStats.receiving}
+                description="Awaiting goods receipt"
+              />
+              <SummaryTile
+                label="Closed"
+                value={orderStats.closed}
+                description="Fully received and reconciled"
+              />
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-4">
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <div className="text-xs uppercase tracking-wide text-slate-500">
+                    Committed spend
+                  </div>
+                  <div className="text-xl font-semibold text-slate-900">
+                    {formatCurrency(orderStats.committed)}
+                  </div>
+                  <p className="mt-1 text-xs text-slate-500">
+                    Derived from {kpi.approved} approved request
+                    {kpi.approved === 1 ? "" : "s"} ready for PO creation.
+                  </p>
+                </div>
+                <div className="grid gap-2 text-sm text-slate-600 sm:min-w-[220px]">
+                  <StatusLine
+                    label="Due in the next 7 days"
+                    value={orderStats.dueSoon}
+                  />
+                  <StatusLine
+                    label="Past-due receipts"
+                    value={orderStats.late}
+                    highlight
+                  />
+                </div>
+              </div>
+            </div>
+          </CardBody>
+        </Card>
+
+        <Card>
+          <CardHeader
+            title="Procurement quick actions"
+            subtitle="Keep purchasing moving fast"
+          />
+          <CardBody className="space-y-3">
+            {QUICK_ACTIONS.map((action) => (
+              <ActionRow key={action.title} {...action} />
+            ))}
+          </CardBody>
+        </Card>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader
+            title="Catalogue coverage"
+            subtitle="Track high-impact categories and catalogue readiness"
+            actions={
+              <Link
+                className="inline-flex items-center gap-1 text-sm font-medium text-blue-700"
+                to="/app/catalog"
+              >
+                Manage catalogue <ArrowUpRight size={16} />
+              </Link>
+            }
+          />
+          <CardBody className="space-y-4">
+            {topCategories.length ? (
+              topCategories.map((cat) => (
+                <CategoryRow key={cat.name} {...cat} />
+              ))
+            ) : (
+              <div className="rounded-xl border border-dashed border-slate-200 px-4 py-6 text-sm text-slate-500">
+                {loading
+                  ? "Loading catalogue insight…"
+                  : "Catalogue activity will appear here as soon as requests reference approved categories."}
+              </div>
+            )}
+            <div className="rounded-xl bg-white/60 px-4 py-3 text-xs text-slate-500">
+              Publish vendor-managed feeds or punchout links from the catalogue workspace to steer compliant buying.
+            </div>
+          </CardBody>
+        </Card>
+
+        <Card>
+          <CardHeader
+            title="Integration & automation"
+            subtitle="Connect purchasing to finance, ERP, and analytics"
+            actions={
+              <Link
+                className="inline-flex items-center gap-1 text-sm font-medium text-blue-700"
+                to="/app/integrations"
+              >
+                Manage integrations <ArrowUpRight size={16} />
+              </Link>
+            }
+          />
+          <CardBody className="space-y-3">
+            {CONNECTOR_SUMMARY.map((connector) => (
+              <ConnectorRow key={connector.id} {...connector} />
+            ))}
+          </CardBody>
+        </Card>
       </section>
 
       <Card>
-        <CardBody>
-          <h3 className="font-semibold mb-3">Recent requests</h3>
-          <div className="divide-y">
-            {recent.map(r=>(
-              <div key={r.id} className="flex items-center justify-between py-2.5">
-                <div>
-                  <div className="font-medium">{r.title}</div>
-                  <div className="text-xs text-slate-500">{r.category_name || '—'} • {new Date(r.created_at).toLocaleDateString()}</div>
-                </div>
-                <div className="flex items-center gap-4">
-                  <div className="text-sm font-medium">${Number(r.amount).toFixed(2)}</div>
-                  <Badge status={r.status}/>
-                </div>
-              </div>
-            ))}
-            {!recent.length && <div className="text-slate-500 py-8 text-center">No requests yet.</div>}
-          </div>
+        <CardHeader
+          title={highlightTitle}
+          subtitle={highlightSubtitle}
+          actions={
+            readyForPo.length ? (
+              <Link
+                className="inline-flex items-center gap-1 text-sm font-medium text-blue-700"
+                to="/app/purchase-orders"
+              >
+                Start PO draft <ArrowUpRight size={16} />
+              </Link>
+            ) : null
+          }
+        />
+        <CardBody className="space-y-3">
+          {highlightedRequests.length ? (
+            highlightedRequests.map((request) => (
+              <RequestRow key={request.id} request={request} />
+            ))
+          ) : (
+            <div className="rounded-xl border border-dashed border-slate-200 px-4 py-6 text-sm text-slate-500">
+              {loading
+                ? "Loading procurement activity…"
+                : "Once requests are submitted and approved, they will appear here ready for purchase order creation."}
+            </div>
+          )}
         </CardBody>
       </Card>
     </div>
   );
 }
 
-function Kpi({title,value}){ 
+function Kpi({ title, value, hint }) {
   return (
-    <Card><CardBody>
-      <div className="text-xs text-slate-500">{title}</div>
-      <motion.div initial={{opacity:0,y:6}} animate={{opacity:1,y:0}} className="text-2xl font-bold">
-        <Counter value={value}/>
-      </motion.div>
-    </CardBody></Card>
+    <Card>
+      <CardBody>
+        <div className="text-xs uppercase tracking-wide text-slate-500">{title}</div>
+        <motion.div
+          initial={{ opacity: 0, y: 6 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="text-2xl font-bold text-slate-900"
+        >
+          <Counter value={Number(value) || 0} />
+        </motion.div>
+        {hint && <div className="mt-1 text-xs text-slate-500">{hint}</div>}
+      </CardBody>
+    </Card>
   );
+}
+
+function SummaryTile({ label, value, description }) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white px-3 py-3">
+      <div className="text-xs uppercase tracking-wide text-slate-500">{label}</div>
+      <div className="text-xl font-semibold text-slate-900">{value}</div>
+      {description && <p className="mt-1 text-xs text-slate-500">{description}</p>}
+    </div>
+  );
+}
+
+function StatusLine({ label, value, highlight }) {
+  const highlightClass = highlight && value
+    ? "text-amber-700"
+    : "text-slate-800";
+  return (
+    <div className="flex items-center justify-between rounded-xl bg-white px-3 py-2 shadow-sm">
+      <span className="text-sm text-slate-600">{label}</span>
+      <span className={`text-sm font-semibold ${highlightClass}`}>{value}</span>
+    </div>
+  );
+}
+
+function ActionRow({ to, title, description, icon: Icon }) {
+  return (
+    <Link
+      to={to}
+      className="group flex items-start gap-3 rounded-xl border border-slate-200 px-3 py-3 transition hover:border-blue-200 hover:bg-blue-50/70"
+    >
+      <div className="flex h-9 w-9 flex-none items-center justify-center rounded-full bg-blue-50 text-blue-600 group-hover:bg-blue-100">
+        {Icon ? <Icon size={18} strokeWidth={1.75} /> : null}
+      </div>
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="font-medium text-slate-800 group-hover:text-blue-700">{title}</div>
+        <p className="text-sm leading-relaxed text-slate-600">{description}</p>
+      </div>
+      <ArrowUpRight className="mt-1 hidden flex-none text-blue-500 group-hover:block" size={16} />
+    </Link>
+  );
+}
+
+function CategoryRow({ name, amount, count, percent }) {
+  const barWidth = Math.max(0, Math.min(100, percent || 0));
+  return (
+    <div className="space-y-2 rounded-2xl border border-slate-200 bg-white px-3 py-3">
+      <div className="flex items-center justify-between">
+        <span className="font-medium text-slate-800">{name}</span>
+        <span className="text-sm font-semibold text-slate-900">{formatCurrency(amount)}</span>
+      </div>
+      <div className="flex items-center justify-between text-xs text-slate-500">
+        <span>{count} request{count === 1 ? "" : "s"}</span>
+        <span>{percent}% of spend</span>
+      </div>
+      <div className="h-2 overflow-hidden rounded-full bg-slate-100">
+        <div
+          className="h-full rounded-full bg-blue-500/80 transition-all"
+          style={{ width: `${barWidth}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ConnectorRow({ name, description, detail, status, icon: Icon }) {
+  return (
+    <div className="flex items-start gap-3 rounded-2xl border border-slate-200 bg-white px-3 py-3">
+      <div className="flex h-9 w-9 flex-none items-center justify-center rounded-full bg-slate-100 text-slate-600">
+        {Icon ? <Icon size={18} strokeWidth={1.75} /> : null}
+      </div>
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-slate-800">{name}</span>
+          <StatusBadge status={status} />
+        </div>
+        <p className="text-sm text-slate-600">{description}</p>
+        {detail && <p className="text-xs text-slate-500">{detail}</p>}
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }) {
+  const key = normalizeStatus(status);
+  const styles = {
+    connected: "bg-emerald-100 text-emerald-700",
+    enabled: "bg-blue-100 text-blue-700",
+    ready: "bg-violet-100 text-violet-700",
+    scheduled: "bg-slate-100 text-slate-600",
+    planned: "bg-slate-100 text-slate-600",
+    "action-required": "bg-amber-100 text-amber-800",
+  };
+  const className = styles[key] || "bg-slate-100 text-slate-600";
+  return (
+    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${className}`}>
+      {status}
+    </span>
+  );
+}
+
+function RequestRow({ request }) {
+  const category = request.categoryLabel || request.category_name || "Uncategorised";
+  const created = formatDate(request.updated_at || request.created_at);
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white px-3 py-3">
+      <div className="min-w-0 space-y-1">
+        <Link
+          to={`/app/requests/${request.id}`}
+          className="truncate font-medium text-slate-800 hover:text-blue-700"
+        >
+          {request.title}
+        </Link>
+        <div className="text-xs text-slate-500">
+          {category} • {formatCurrency(request.amount)}
+        </div>
+      </div>
+      <div className="flex shrink-0 flex-col items-end gap-2 text-xs text-slate-500">
+        <Badge status={request.status} />
+        <span>{created}</span>
+      </div>
+    </div>
+  );
+}
+
+function normalizeStatus(value) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_]+/g, "-");
+}
+
+function toNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : 0;
+}
+
+function safeNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) && num > 0 ? Math.round(num) : 0;
+}
+
+function formatCurrency(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return "$0.00";
+  return `$${num.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function getTimestamp(value) {
+  if (!value) return 0;
+  const date = new Date(value);
+  const time = date.getTime();
+  return Number.isNaN(time) ? 0 : time;
+}
+
+function formatDate(value) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleDateString();
+}
+
+function getOrderStatus(order) {
+  return pickField(order, ["status", "state", "stage"]);
+}
+
+function getOrderTotal(order) {
+  return toNumber(
+    pickField(order, [
+      "total",
+      "amount",
+      "value",
+      "grand_total",
+      "grandTotal",
+    ])
+  );
+}
+
+function getExpectedDate(order) {
+  const raw = pickField(order, [
+    "expected_date",
+    "expectedDate",
+    "due_date",
+    "dueDate",
+    "delivery_date",
+    "deliveryDate",
+  ]);
+  if (!raw) return null;
+  const date = new Date(raw);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function pickField(record, fields) {
+  for (const key of fields) {
+    const value = record?.[key];
+    if (value !== undefined && value !== null && value !== "") {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function resolveCategoryName(request, categoryById) {
+  const rawId = request?.category_id;
+  if (rawId !== undefined && rawId !== null) {
+    const id = Number(rawId);
+    if (!Number.isNaN(id)) {
+      const match = categoryById.get(id);
+      if (match?.name) return match.name;
+    }
+  }
+  if (request?.category_name) return request.category_name;
+  return "Uncategorised";
 }

--- a/frontend/src/pages/Integrations.jsx
+++ b/frontend/src/pages/Integrations.jsx
@@ -1,0 +1,272 @@
+import {
+  ArrowUpRight,
+  FileSpreadsheet,
+  Globe2,
+  Workflow,
+  Plug,
+  Boxes,
+} from "lucide-react";
+import { Link } from "react-router-dom";
+import { Card, CardBody, CardHeader } from "../components/Card";
+
+const CONNECTORS = [
+  {
+    id: "punchout",
+    type: "punchout",
+    name: "PunchOut storefronts",
+    status: "Enabled",
+    cadence: "Real-time",
+    description:
+      "Launch supplier-hosted catalogues via cXML or OCI, maintain SSO, and return carts directly into requisitions.",
+    detail:
+      "Includes cart replay, audit logging, and configurable timeouts so finance can trace every PunchOut session.",
+    icon: Globe2,
+    capabilities: ["cXML + OCI", "SSO handshake", "Cart replay"],
+  },
+  {
+    id: "erp",
+    type: "erp",
+    name: "ERP & AP automation",
+    status: "Connected",
+    cadence: "Every 30 min",
+    description:
+      "Push approved purchase orders, receipts, and change orders into NetSuite, SAP, Oracle, or Workday.",
+    detail:
+      "Two-way sync keeps supplier confirmations and invoice status aligned with procurement records.",
+    icon: Workflow,
+    capabilities: ["NetSuite", "SAP", "Oracle", "Workday"],
+  },
+  {
+    id: "ap",
+    type: "ap",
+    name: "Accounts payable",
+    status: "Ready",
+    cadence: "Real-time webhooks",
+    description:
+      "Notify AP automation platforms when receipts clear or when three-way match exceptions occur.",
+    detail:
+      "Supports Tipalti, Coupa Pay, and custom SFTP drops for payment batches.",
+    icon: Plug,
+    capabilities: ["Tipalti", "Coupa Pay", "Custom SFTP"],
+  },
+  {
+    id: "analytics",
+    type: "data",
+    name: "Analytics & data warehouse",
+    status: "Scheduled",
+    cadence: "Nightly",
+    description:
+      "Export purchasing, supplier, and receipt data to Snowflake, Power BI, or BigQuery for finance analytics.",
+    detail:
+      "Incremental loads include delta flags, cost center splits, and approval history for downstream reporting.",
+    icon: Boxes,
+    capabilities: ["Snowflake", "Power BI", "BigQuery"],
+  },
+];
+
+const AUTOMATIONS = [
+  {
+    title: "REST & GraphQL APIs",
+    description:
+      "Programmatically create requests, issue purchase orders, manage catalogue content, and sync vendor records.",
+    icon: Workflow,
+  },
+  {
+    title: "Webhooks & events",
+    description:
+      "Receive instant notifications when requests are approved, purchase orders are sent, or receipts are posted.",
+    icon: Plug,
+  },
+  {
+    title: "EDI & cXML messaging",
+    description:
+      "Exchange 850/855/856 documents, confirmations, and ship notices with suppliers to minimise manual follow-up.",
+    icon: Globe2,
+  },
+  {
+    title: "Scheduled exports",
+    description:
+      "Deliver CSV, SFTP, or cloud-storage feeds on custom cadences for finance, FP&A, and audit teams.",
+    icon: FileSpreadsheet,
+  },
+];
+
+const PLAYBOOK = [
+  "Connect finance systems first so approved purchase orders land where budgets live.",
+  "Enable punchout storefronts for preferred suppliers to keep shopping compliant.",
+  "Subscribe to webhook alerts for high-value approvals and policy exceptions.",
+  "Schedule data warehouse exports to keep analytics and forecasting up to date.",
+];
+
+export default function Integrations() {
+  const connectedCount = CONNECTORS.filter((connector) =>
+    ["connected", "enabled", "ready"].includes(normalizeStatus(connector.status))
+  ).length;
+  const punchoutCount = CONNECTORS.filter((connector) => connector.type === "punchout").length;
+  const automationCount = AUTOMATIONS.length;
+  const cadences = Array.from(new Set(CONNECTORS.map((connector) => connector.cadence).filter(Boolean)));
+  const cadenceSummary = cadences.join(" • ");
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader
+          title="Integration overview"
+          subtitle="Keep procurement, finance, and suppliers connected without manual reconciliation"
+        />
+        <CardBody>
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+            <IntegrationMetric label="Connected systems" value={connectedCount} />
+            <IntegrationMetric label="PunchOut storefronts" value={punchoutCount} />
+            <IntegrationMetric label="Automation recipes" value={automationCount} />
+            <IntegrationMetric label="Delivery cadence" value={cadenceSummary || "Configurable"} isText />
+          </div>
+          <p className="mt-4 text-sm text-slate-600">
+            Automations prioritise purchase orders, catalogue governance, and supplier collaboration so finance has a
+            single source of truth.
+          </p>
+        </CardBody>
+      </Card>
+
+      <Card id="punchout">
+        <CardHeader
+          title="Connectors"
+          subtitle="Certified integrations for punchout, ERP, AP automation, and analytics"
+          actions={
+            <Link
+              className="inline-flex items-center gap-1 text-sm font-medium text-blue-700"
+              to="/app/purchase-orders"
+            >
+              Send a test PO <ArrowUpRight size={16} />
+            </Link>
+          }
+        />
+        <CardBody className="space-y-3">
+          {CONNECTORS.map((connector) => (
+            <ConnectorRow key={connector.id} connector={connector} />
+          ))}
+        </CardBody>
+      </Card>
+
+      <Card id="automation">
+        <CardHeader
+          title="Integration & automation toolkit"
+          subtitle="Build workflows and analytics pipelines around purchasing"
+          actions={
+            <Link
+              className="inline-flex items-center gap-1 text-sm font-medium text-blue-700"
+              to="/app/catalog"
+            >
+              Sync catalogue <ArrowUpRight size={16} />
+            </Link>
+          }
+        />
+        <CardBody className="space-y-3">
+          {AUTOMATIONS.map((item) => (
+            <AutomationRow key={item.title} item={item} />
+          ))}
+          <div className="rounded-2xl border border-dashed border-slate-200 px-4 py-3 text-xs text-slate-500">
+            Need custom endpoints or credentials? Contact the integrations team for sandbox access and API keys.
+          </div>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardHeader
+          title="Integration playbook"
+          subtitle="Sequence the rollout so purchasing and finance stay in lockstep"
+        />
+        <CardBody className="space-y-4 text-sm text-slate-600">
+          <ol className="list-decimal list-inside space-y-3">
+            {PLAYBOOK.map((step, index) => (
+              <li key={index}>{step}</li>
+            ))}
+          </ol>
+          <div className="rounded-2xl bg-slate-50 px-4 py-3 text-xs text-slate-500">
+            Monitor integration health from the dashboard and review audit logs before closing the month.
+          </div>
+        </CardBody>
+      </Card>
+    </div>
+  );
+}
+
+function IntegrationMetric({ label, value, isText }) {
+  const display = isText ? value : Number(value) || 0;
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white px-3 py-3">
+      <div className="text-xs uppercase tracking-wide text-slate-500">{label}</div>
+      <div className="mt-1 text-xl font-semibold text-slate-900">
+        {isText ? display : display.toLocaleString()}
+      </div>
+    </div>
+  );
+}
+
+function ConnectorRow({ connector }) {
+  const { icon: Icon, name, status, cadence, description, detail, capabilities } = connector;
+  return (
+    <div className="flex items-start gap-3 rounded-2xl border border-slate-200 bg-white px-3 py-3">
+      <div className="flex h-9 w-9 flex-none items-center justify-center rounded-full bg-slate-100 text-slate-600">
+        {Icon ? <Icon size={18} strokeWidth={1.75} /> : null}
+      </div>
+      <div className="min-w-0 flex-1 space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="font-medium text-slate-800">{name}</span>
+          <StatusBadge status={status} />
+          {cadence && <span className="text-xs text-slate-500">{cadence}</span>}
+        </div>
+        <p className="text-sm text-slate-600">{description}</p>
+        {Array.isArray(capabilities) && capabilities.length > 0 && (
+          <ul className="flex flex-wrap gap-2 text-xs text-slate-500">
+            {capabilities.map((capability) => (
+              <li key={capability} className="rounded-full bg-slate-100 px-2 py-1">
+                {capability}
+              </li>
+            ))}
+          </ul>
+        )}
+        {detail && <p className="text-xs text-slate-500">{detail}</p>}
+      </div>
+    </div>
+  );
+}
+
+function AutomationRow({ item }) {
+  const { icon: Icon, title, description } = item;
+  return (
+    <div className="flex items-start gap-3 rounded-2xl border border-slate-200 bg-white px-3 py-3">
+      <div className="flex h-9 w-9 flex-none items-center justify-center rounded-full bg-blue-50 text-blue-600">
+        {Icon ? <Icon size={18} strokeWidth={1.75} /> : null}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="font-medium text-slate-800">{title}</div>
+        <p className="text-sm text-slate-600">{description}</p>
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }) {
+  const key = normalizeStatus(status);
+  const classes = {
+    connected: "bg-emerald-100 text-emerald-700",
+    enabled: "bg-blue-100 text-blue-700",
+    ready: "bg-violet-100 text-violet-700",
+    scheduled: "bg-slate-100 text-slate-600",
+    "in-progress": "bg-amber-100 text-amber-800",
+  };
+  const className = classes[key] || "bg-slate-100 text-slate-600";
+  return (
+    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${className}`}>
+      {status}
+    </span>
+  );
+}
+
+function normalizeStatus(value) {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_]+/g, "-");
+}


### PR DESCRIPTION
## Summary
- Restructure the authenticated shell with a finance-focused hero, quick links to purchasing tasks, and navigation entries for purchase orders, catalogue, and integrations.
- Expand the dashboard to surface purchase order KPIs, procurement quick actions, category coverage, and integration status insights.
- Introduce dedicated catalogue and integrations hub pages with punchout guidance and automation playbooks, wiring new routes into the app.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d3496b3d70832aa8bf31e67550bd56