### PR TITLE
Refactor app routing to separate authenticated pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,11 @@
-import { Outlet, NavLink, useLocation, Link } from "react-router-dom";
+import {
+  NavLink,
+  Link,
+  Routes,
+  Route,
+  Navigate,
+  useLocation,
+} from "react-router-dom";
 import {
   LogOut,
   ShoppingCart,
@@ -15,6 +22,15 @@ import {
 import { AnimatePresence, motion } from "framer-motion";
 import ThemeToggle from "./components/ThemeToggle";
 import { useAuth } from "./lib/auth";
+import Dashboard from "./pages/Dashboard";
+import PurchaseOrders from "./pages/PurchaseOrders";
+import Catalog from "./pages/Catalog";
+import Requests from "./pages/Requests";
+import RequestDetailRoute from "./pages/RequestDetailRoute";
+import Approvals from "./pages/Approvals";
+import Vendors from "./pages/Vendors";
+import Integrations from "./pages/Integrations";
+import Settings from "./pages/Settings";
 
 const NAV_ITEMS = {
   dashboard: {
@@ -305,7 +321,7 @@ export default function App() {
           </div>
         </header>
 
-        <AnimatedOutlet />
+        <AnimatedRoutes />
         <footer className="px-4 py-6 text-xs text-slate-500 md:px-8">
           © {new Date().getFullYear()} Procurement workspace
         </footer>
@@ -314,7 +330,7 @@ export default function App() {
   );
 }
 
-function AnimatedOutlet() {
+function AnimatedRoutes() {
   const location = useLocation();
   return (
     <div className="container mx-auto px-4 py-6 md:px-8">
@@ -322,14 +338,89 @@ function AnimatedOutlet() {
         <motion.div
           key={location.pathname}
           initial={{ opacity: 0, y: 6 }}
-          animate={{ opacity: 1, y: 0, transition: { duration: .24, ease: 'easeOut' } }}
-          exit={{ opacity: 0, y: -6, transition: { duration: .18 } }}
-          className="space-y-6"
+          animate={{ opacity: 1, y: 0, transition: { duration: 0.24, ease: "easeOut" } }}
+          exit={{ opacity: 0, y: -6, transition: { duration: 0.18 } }}
         >
-          <Hero />
-          <Outlet />
+          <Routes location={location}>
+            <Route
+              index
+              element={
+                <PageShell>
+                  <Dashboard />
+                </PageShell>
+              }
+            />
+            <Route
+              path="purchase-orders"
+              element={
+                <PageShell>
+                  <PurchaseOrders />
+                </PageShell>
+              }
+            />
+            <Route
+              path="catalog"
+              element={
+                <PageShell>
+                  <Catalog />
+                </PageShell>
+              }
+            />
+            <Route
+              path="requests"
+              element={
+                <PageShell>
+                  <Requests />
+                </PageShell>
+              }
+            >
+              <Route path=":id" element={<RequestDetailRoute />} />
+            </Route>
+            <Route
+              path="approvals"
+              element={
+                <PageShell>
+                  <Approvals />
+                </PageShell>
+              }
+            />
+            <Route
+              path="vendors"
+              element={
+                <PageShell>
+                  <Vendors />
+                </PageShell>
+              }
+            />
+            <Route
+              path="integrations"
+              element={
+                <PageShell>
+                  <Integrations />
+                </PageShell>
+              }
+            />
+            <Route
+              path="settings"
+              element={
+                <PageShell>
+                  <Settings />
+                </PageShell>
+              }
+            />
+            <Route path="*" element={<Navigate to="/app" replace />} />
+          </Routes>
         </motion.div>
       </AnimatePresence>
+    </div>
+  );
+}
+
+function PageShell({ children }) {
+  return (
+    <div className="space-y-6">
+      <Hero />
+      {children}
     </div>
   );
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,15 +5,6 @@ import "./index.css";
 import Landing from "./pages/Landing";
 import IntakeChecklist from "./pages/IntakeChecklist";
 import App from "./App";
-import Dashboard from "./pages/Dashboard";
-import Requests from "./pages/Requests";
-import RequestDetailRoute from "./pages/RequestDetailRoute";
-import Approvals from "./pages/Approvals";
-import Settings from "./pages/Settings";
-import Vendors from "./pages/Vendors";
-import PurchaseOrders from "./pages/PurchaseOrders";
-import Catalog from "./pages/Catalog";
-import Integrations from "./pages/Integrations";
 import Login from "./pages/Login";
 import Signup from "./pages/Signup";
 import { AuthProvider, RequireAuth } from "./lib/auth";
@@ -31,24 +22,13 @@ ReactDOM.createRoot(document.getElementById("root")).render(
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
           <Route
-            path="/app"
+            path="/app/*"
             element={(
               <RequireAuth>
                 <App />
               </RequireAuth>
             )}
-          >
-            <Route index element={<Dashboard />} />
-            <Route path="purchase-orders" element={<PurchaseOrders />} />
-            <Route path="catalog" element={<Catalog />} />
-            <Route path="requests" element={<Requests />}>
-              <Route path=":id" element={<RequestDetailRoute />} />
-            </Route>
-            <Route path="approvals" element={<Approvals />} />
-            <Route path="settings" element={<Settings />} />
-            <Route path="vendors" element={<Vendors />} />
-            <Route path="integrations" element={<Integrations />} />
-          </Route>
+          />
         </Routes>
       </AuthProvider>
     </BrowserRouter>

--- a/frontend/src/test-setup.js
+++ b/frontend/src/test-setup.js
@@ -1,0 +1,23 @@
+class MockIntersectionObserver {
+  constructor() {}
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() { return []; }
+}
+
+if (typeof window !== 'undefined') {
+  if (!('IntersectionObserver' in window)) {
+    window.IntersectionObserver = MockIntersectionObserver;
+  }
+  if (!('IntersectionObserverEntry' in window)) {
+    window.IntersectionObserverEntry = class {};
+  }
+}
+
+if (!('IntersectionObserver' in globalThis)) {
+  globalThis.IntersectionObserver = MockIntersectionObserver;
+}
+if (!('IntersectionObserverEntry' in globalThis)) {
+  globalThis.IntersectionObserverEntry = class {};
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -15,6 +15,7 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    environment: 'jsdom'
+    environment: 'jsdom',
+    setupFiles: './src/test-setup.js'
   }
 })


### PR DESCRIPTION
## Summary
- replace the outlet in `App` with explicit nested routes so each nav item renders its own page shell after sign-in
- update the root router to mount the authenticated workspace at `/app/*`
- add a Vitest setup file that stubs `IntersectionObserver` for animated views

## Testing
- npm --prefix frontend test

------
https://chatgpt.com/codex/tasks/task_e_68d35240d2c0832a8319139b96a13ac2