### PR TITLE
Enhance purchase orders dashboard with filters and insights

### DIFF
--- a/frontend/src/pages/PurchaseOrders.jsx
+++ b/frontend/src/pages/PurchaseOrders.jsx
@@ -3,12 +3,16 @@ import { Card, CardBody, CardHeader } from "../components/Card";
 import { T, Th, Td } from "../components/Table";
 import Button from "../components/Button";
 import Badge from "../components/Badge";
+import Chip from "../components/Chip";
 import SkeletonRow from "../components/SkeletonRow";
 import Drawer from "../components/Drawer";
 import { useToast } from "../components/toast";
 import { apiDelete, apiGet, apiPatch, apiPost } from "../lib/api";
 
 const ORDER_STATUSES = ["draft", "issued", "receiving", "received", "cancelled"];
+const STATUS_FILTERS = ["all", ...ORDER_STATUSES];
+const ACTIVE_STATUSES = new Set(["draft", "issued", "receiving"]);
+const DAY_IN_MS = 1000 * 60 * 60 * 24;
 const INITIAL_FORM = {
   poNumber: "",
   vendorId: "",
@@ -28,6 +32,8 @@ export default function PurchaseOrders() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [onlyOverdue, setOnlyOverdue] = useState(false);
 
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [editing, setEditing] = useState(null);
@@ -75,8 +81,17 @@ export default function PurchaseOrders() {
   const filtered = useMemo(() => {
     const list = Array.isArray(orders) ? orders : [];
     const term = search.trim().toLowerCase();
-    if (!term) return list;
     return list.filter((order) => {
+      const status = getStatus(order);
+      if (statusFilter !== "all" && status !== statusFilter) {
+        return false;
+      }
+      if (onlyOverdue && !isOrderOverdue(order)) {
+        return false;
+      }
+
+      if (!term) return true;
+
       const values = [
         pickField(order, ["po_number", "poNumber", "number", "id"]),
         pickField(order, ["vendor_name", "vendor", "vendorName"]),
@@ -89,11 +104,49 @@ export default function PurchaseOrders() {
         value && value.toString().toLowerCase().includes(term)
       );
     });
-  }, [orders, search]);
+  }, [orders, search, statusFilter, onlyOverdue]);
 
-  const emptyMessage = orders.length
-    ? "No purchase orders match your search."
+  const summary = useMemo(() => {
+    const list = Array.isArray(orders) ? orders : [];
+    let totalValue = 0;
+    let openCount = 0;
+    let pendingValue = 0;
+    let overdueCount = 0;
+
+    list.forEach((order) => {
+      const status = getStatus(order);
+      if (ACTIVE_STATUSES.has(status)) {
+        openCount += 1;
+      }
+      const amount = parseAmount(
+        pickField(order, ["total", "amount", "value"])
+      );
+      if (amount !== null) {
+        totalValue += amount;
+        if (status === "issued" || status === "receiving") {
+          pendingValue += amount;
+        }
+      }
+      if (isOrderOverdue(order)) {
+        overdueCount += 1;
+      }
+    });
+
+    return {
+      totalCount: list.length,
+      totalValue,
+      openCount,
+      pendingValue,
+      overdueCount,
+    };
+  }, [orders]);
+
+  const hasActiveFilters = Boolean(search.trim()) || statusFilter !== "all" || onlyOverdue;
+
+  const emptyMessage = summary.totalCount
+    ? "No purchase orders match your filters."
     : "No purchase orders yet.";
+  const isInitialLoading = loading && !orders.length;
 
   function openNewDrawer() {
     setEditing(null);
@@ -156,6 +209,12 @@ export default function PurchaseOrders() {
     setSaving(false);
     setDeleting(false);
   }
+
+  const handleResetFilters = useCallback(() => {
+    setStatusFilter("all");
+    setOnlyOverdue(false);
+    setSearch("");
+  }, []);
 
   function handleVendorSelect(event) {
     const value = event.target.value;
@@ -244,6 +303,54 @@ export default function PurchaseOrders() {
 
   return (
     <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <SummaryTile
+          label="Total purchase orders"
+          value={
+            isInitialLoading
+              ? "…"
+              : summary.totalCount.toLocaleString()
+          }
+          hint="Across all statuses"
+          tone={isInitialLoading ? "text-slate-400" : undefined}
+        />
+        <SummaryTile
+          label="Open orders"
+          value={
+            isInitialLoading
+              ? "…"
+              : summary.openCount.toLocaleString()
+          }
+          hint={
+            isInitialLoading
+              ? ""
+              : `${formatCurrency(summary.pendingValue)} awaiting receipt`
+          }
+          tone={isInitialLoading ? "text-slate-400" : undefined}
+        />
+        <SummaryTile
+          label="Total PO value"
+          value={isInitialLoading ? "…" : formatCurrency(summary.totalValue)}
+          hint="Combined value of every purchase order"
+          tone={isInitialLoading ? "text-slate-400" : undefined}
+        />
+        <SummaryTile
+          label="Overdue deliveries"
+          value={
+            isInitialLoading
+              ? "…"
+              : summary.overdueCount.toLocaleString()
+          }
+          hint="Past expected delivery date"
+          tone={
+            isInitialLoading
+              ? "text-slate-400"
+              : summary.overdueCount
+              ? "text-red-600"
+              : "text-slate-900"
+          }
+        />
+      </div>
       <Card>
         <CardHeader
           title="Purchase orders"
@@ -271,6 +378,50 @@ export default function PurchaseOrders() {
               Failed to load purchase orders: {error}
             </div>
           )}
+          <div className="flex flex-col gap-3 border-b border-slate-100 px-5 py-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex flex-wrap gap-2">
+              {STATUS_FILTERS.map((status) => {
+                const label =
+                  status === "all"
+                    ? "All"
+                    : status.charAt(0).toUpperCase() + status.slice(1);
+                return (
+                  <Chip
+                    key={status}
+                    active={statusFilter === status}
+                    onClick={() => setStatusFilter(status)}
+                  >
+                    {label}
+                  </Chip>
+                );
+              })}
+            </div>
+            <div className="flex flex-wrap items-center gap-3 text-xs sm:text-sm text-slate-600">
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                  checked={onlyOverdue}
+                  onChange={(event) => setOnlyOverdue(event.target.checked)}
+                />
+                Show overdue deliveries only
+              </label>
+              {!loading && (
+                <span className="text-slate-500">
+                  Showing {filtered.length} of {summary.totalCount} purchase orders
+                </span>
+              )}
+              {hasActiveFilters && (
+                <button
+                  type="button"
+                  onClick={handleResetFilters}
+                  className="text-xs font-medium text-blue-600 hover:text-blue-700"
+                >
+                  Reset filters
+                </button>
+              )}
+            </div>
+          </div>
           <div className="overflow-x-auto rounded-2xl">
             <T>
               <thead className="bg-slate-50">
@@ -304,10 +455,7 @@ export default function PurchaseOrders() {
                     const vendorId = pickField(order, ["vendor_id", "vendorId"]);
                     const totalRaw = pickField(order, ["total", "amount", "value"]);
                     const total = formatCurrency(totalRaw);
-                    const rawStatus = pickField(order, ["status", "state", "stage"]);
-                    const status = rawStatus
-                      ? rawStatus.toString().toLowerCase()
-                      : "";
+                    const status = getStatus(order);
                     const updatedRaw = pickField(order, [
                       "updated_at",
                       "updatedAt",
@@ -318,22 +466,15 @@ export default function PurchaseOrders() {
                       "issuedAt",
                     ]);
                     const updated = formatDate(updatedRaw);
-                    const dueRaw = pickField(order, [
-                      "expected_date",
-                      "expectedDate",
-                      "due_at",
-                      "dueAt",
-                      "due_date",
-                      "dueDate",
-                      "delivery_date",
-                      "deliveryDate",
-                    ]);
-                    const due = formatDate(dueRaw);
+                    const dueDetails = getDueDetails(order);
+                    const overdue = isOrderOverdue(order);
 
                     return (
                       <tr
                         key={key}
-                        className="border-b border-slate-100 transition hover:bg-slate-50"
+                        className={`border-b border-slate-100 transition ${
+                          overdue ? "bg-red-50/70 hover:bg-red-100/70" : "hover:bg-slate-50"
+                        }`}
                       >
                         <Td>
                           <div className="font-medium">{poNumber}</div>
@@ -357,8 +498,10 @@ export default function PurchaseOrders() {
                         </Td>
                         <Td>
                           <div>{updated}</div>
-                          {dueRaw && (
-                            <div className="text-xs text-slate-500">Due {due}</div>
+                          {dueDetails.message && (
+                            <div className={`text-xs ${dueDetails.tone}`}>
+                              {dueDetails.message}
+                            </div>
                           )}
                         </Td>
                         <Td align="right">
@@ -547,6 +690,16 @@ export default function PurchaseOrders() {
   );
 }
 
+function SummaryTile({ label, value, hint, tone = "text-slate-900" }) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-sm">
+      <div className="text-xs uppercase tracking-wide text-slate-500">{label}</div>
+      <div className={`text-xl font-semibold ${tone}`}>{value}</div>
+      {hint ? <div className="mt-1 text-xs text-slate-500">{hint}</div> : null}
+    </div>
+  );
+}
+
 function pickField(order, fields) {
   for (const key of fields) {
     const value = order?.[key];
@@ -555,6 +708,102 @@ function pickField(order, fields) {
     }
   }
   return undefined;
+}
+
+function getStatus(order) {
+  const raw = pickField(order, ["status", "state", "stage"]);
+  if (raw === undefined || raw === null) return "";
+  return raw.toString().toLowerCase();
+}
+
+function parseAmount(value) {
+  if (value === undefined || value === null || value === "") return null;
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string") {
+    const cleaned = value.replace(/[^0-9.-]+/g, "");
+    if (!cleaned) return null;
+    const parsed = Number(cleaned);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function getDueDate(order) {
+  const raw = pickField(order, [
+    "expected_date",
+    "expectedDate",
+    "due_at",
+    "dueAt",
+    "due_date",
+    "dueDate",
+    "delivery_date",
+    "deliveryDate",
+  ]);
+  if (!raw) return null;
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) return null;
+  return date;
+}
+
+function isOrderOverdue(order) {
+  const status = getStatus(order);
+  if (!status || status === "received" || status === "cancelled") {
+    return false;
+  }
+  const dueDate = getDueDate(order);
+  if (!dueDate) return false;
+  const endOfDue = new Date(dueDate);
+  endOfDue.setHours(23, 59, 59, 999);
+  return endOfDue.getTime() < Date.now();
+}
+
+function getDueDetails(order) {
+  const dueDate = getDueDate(order);
+  if (!dueDate) {
+    return { message: "", tone: "text-slate-500" };
+  }
+
+  const status = getStatus(order);
+  const formattedDate = formatDate(dueDate);
+  const isFinalized = status === "received" || status === "cancelled";
+  const endOfDue = new Date(dueDate);
+  endOfDue.setHours(23, 59, 59, 999);
+  const diffMs = endOfDue.getTime() - Date.now();
+  const diffDays = Math.ceil(diffMs / DAY_IN_MS);
+
+  if (!isFinalized && diffMs < 0) {
+    const overdueDays = Math.abs(diffDays);
+    const overdueText =
+      overdueDays > 0
+        ? `Overdue by ${overdueDays} day${overdueDays === 1 ? "" : "s"}`
+        : "Overdue";
+    return {
+      message: `${overdueText} • ${formattedDate}`,
+      tone: "text-red-600",
+    };
+  }
+
+  if (!isFinalized && diffDays === 0) {
+    return {
+      message: `Due today • ${formattedDate}`,
+      tone: "text-amber-600",
+    };
+  }
+
+  if (!isFinalized && diffDays > 0 && diffDays <= 3) {
+    return {
+      message: `Due in ${diffDays} day${diffDays === 1 ? "" : "s"} • ${formattedDate}`,
+      tone: "text-amber-600",
+    };
+  }
+
+  return {
+    message: `Expected ${formattedDate}`,
+    tone: "text-slate-500",
+  };
 }
 
 function formatCurrency(value) {


### PR DESCRIPTION
## Summary
- add status filter chips, an overdue toggle, and a reset control to refine purchase order results
- surface purchase order KPIs, including counts and value rollups, ahead of the table for at-a-glance monitoring
- highlight delivery expectations by computing due details and overdue styling directly in each row

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68d361dfd640832abb355e590d2c005c